### PR TITLE
Rewrites the method which parses annotation constraint provided by Ion Schema.

### DIFF
--- a/src/com/amazon/ion/benchmark/IonSchemaUtilities.java
+++ b/src/com/amazon/ion/benchmark/IonSchemaUtilities.java
@@ -32,6 +32,8 @@ public class IonSchemaUtilities {
     public static final String KEYWORD_ORDERED = "ordered";
     public static final String KEYWORD_NAME = "name";
     public static final String KEYWORD_CONTAINER_LENGTH = "container_length";
+    public static final String KEYWORD_MIN = "min";
+    public static final String KEYWORD_MAX = "max";
 
     /**
      * Extract the value of the constraints, select from the set (occurs | container_length | codepoint_length).
@@ -43,7 +45,7 @@ public class IonSchemaUtilities {
     public static int parseConstraints(IonStruct value, String keyWord) throws IOException {
         Random random = new Random();
         int result = 0;
-        int min = 0;
+        int min;
         int max;
         try (IonReader reader = IonReaderBuilder.standard().build(value)) {
             reader.next();
@@ -67,12 +69,22 @@ public class IonSchemaUtilities {
                         case LIST:
                             reader.stepIn();
                             reader.next();
-                            if (reader.getType() != IonType.SYMBOL) {
+                            if (reader.getType() == IonType.SYMBOL) {
+                                if (reader.symbolValue().equals(KEYWORD_MIN)) {
+                                    min = 0;
+                                } else {
+                                    throw new IllegalStateException("The lower bound symbol value is not supported in Ion Schema");
+                                }
+                            } else {
                                 min = reader.intValue();
                             }
                             reader.next();
                             if (reader.getType() == IonType.SYMBOL) {
-                                max = Integer.MAX_VALUE;
+                                if (reader.symbolValue().equals(KEYWORD_MAX)) {
+                                    max = Integer.MAX_VALUE;
+                                } else {
+                                    throw new IllegalStateException("The upper bound symbol value is not supported in Ion Schema");
+                                }
                             } else {
                                 max = reader.intValue();
                             }

--- a/src/com/amazon/ion/benchmark/IonSchemaUtilities.java
+++ b/src/com/amazon/ion/benchmark/IonSchemaUtilities.java
@@ -147,9 +147,9 @@ public class IonSchemaUtilities {
         if (!constraint.contains(IonSchemaUtilities.KEYWORD_ORDERED)) {
             List<IonValue> annotations = annotationList.stream().collect(Collectors.toList());
             Collections.shuffle(annotations);
-            try (IonReader shuffledAnnotationReader = IonReaderBuilder.standard().build(annotations.toString())) {
-                shuffledAnnotationReader.next();
-                result = (IonList) ReadGeneralConstraints.SYSTEM.newValue(shuffledAnnotationReader);
+            result = ReadGeneralConstraints.SYSTEM.newEmptyList();
+            for (int index = 0; index < annotations.size(); index++) {
+                result.add(index, annotations.get(index).clone());
             }
         }
         return checkRequired(constraint, result,random);
@@ -170,9 +170,9 @@ public class IonSchemaUtilities {
             int randomValueTwo = random.nextInt(annotationList.size());
             List<IonValue> subAnnotationList = annotationList.subList(Math.min(randomValueOne, randomValueTwo), Math.max(randomValueOne, randomValueTwo));
             if (subAnnotationList != null) {
-                try (IonReader annotationReader = IonReaderBuilder.standard().build(subAnnotationList.toString())) {
-                    annotationReader.next();
-                    result = (IonList) ReadGeneralConstraints.SYSTEM.newValue(annotationReader);
+                result = ReadGeneralConstraints.SYSTEM.newEmptyList();
+                for (int index = 0; index < subAnnotationList.size(); index++) {
+                    result.add(index, subAnnotationList.get(index).clone());
                 }
             } else {
                 result = null;

--- a/src/com/amazon/ion/benchmark/IonSchemaUtilities.java
+++ b/src/com/amazon/ion/benchmark/IonSchemaUtilities.java
@@ -9,15 +9,17 @@ import com.amazon.ion.Timestamp;
 import com.amazon.ion.system.IonReaderBuilder;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Random;
+import java.util.stream.Collectors;
 
 /**
  * Contain the methods which process the constraints provided by the Ion Schema file and define the constants relevant to the Ion Schema file.
  */
 public class IonSchemaUtilities {
-    public static final String KEYWORD_ANNOTATIONS = "Annotations";
+    public static final String KEYWORD_ANNOTATIONS = "annotations";
     public static final String KEYWORD_REQUIRED = "required";
     public static final String KEYWORD_OPTIONAL = "optional";
     public static final String KEYWORD_TIMESTAMP_PRECISION = "timestamp_precision";
@@ -28,8 +30,8 @@ public class IonSchemaUtilities {
     public static final String KEYWORD_ELEMENT = "element";
     public static final String KEYWORD_ORDERED_ELEMENTS = "ordered_elements";
     public static final String KEYWORD_ORDERED = "ordered";
-    public static final String KEYWORD_CONSTRAINT = "constraint";
     public static final String KEYWORD_NAME = "name";
+    public static final String KEYWORD_CONTAINER_LENGTH = "container_length";
 
     /**
      * Extract the value of the constraints, select from the set (occurs | container_length | codepoint_length).
@@ -41,6 +43,8 @@ public class IonSchemaUtilities {
     public static int parseConstraints(IonStruct value, String keyWord) throws IOException {
         Random random = new Random();
         int result = 0;
+        int min = 0;
+        int max;
         try (IonReader reader = IonReaderBuilder.standard().build(value)) {
             reader.next();
             reader.stepIn();
@@ -63,9 +67,15 @@ public class IonSchemaUtilities {
                         case LIST:
                             reader.stepIn();
                             reader.next();
-                            int min = reader.intValue();
+                            if (reader.getType() != IonType.SYMBOL) {
+                                min = reader.intValue();
+                            }
                             reader.next();
-                            int max = reader.intValue();
+                            if (reader.getType() == IonType.SYMBOL) {
+                                max = Integer.MAX_VALUE;
+                            } else {
+                                max = reader.intValue();
+                            }
                             result = random.nextInt(max - min + 1) + min;
                             break;
                     }
@@ -101,25 +111,73 @@ public class IonSchemaUtilities {
     }
 
     /**
-     * Return the information of annotations in a HashMap which includes the constraint and values of annotation. The constraint is the from set(optional | required |ordered)
-     * @param value is the Ion struct which contain the current constraint field.
-     * @return a HashMap contains the information of annotations, both the constraint of the annotation and the value of the annotation.
+     * Parse the field 'annotations' based on the provided constraints (required|ordered).
+     * @param constraintStruct contains the top-level constraints of Ion Schema.
+     * @return IonList which contains annotations
+     * @throws IOException if error occur when reading constraints.
      */
-    public static Map<String, Object> getAnnotation(IonStruct value) {
-        Map<String, Object> annotationMap = new HashMap<>();
-        IonValue annotations = value.get(KEYWORD_ANNOTATIONS);
-        if (annotations != null) {
-            IonList annotationList = (IonList) value.get(KEYWORD_ANNOTATIONS);
-            if (annotations.getTypeAnnotations().length != 0) {
-                String annotationConstraint = annotations.getTypeAnnotations()[0];
-                annotationMap.put(KEYWORD_CONSTRAINT, annotationConstraint);
-            } else {
-                annotationMap.put(KEYWORD_CONSTRAINT, KEYWORD_OPTIONAL);
+    public static IonList getAnnotation(IonStruct constraintStruct) throws IOException {
+        IonList annotationList = null;
+        Random random = new Random();
+        try (IonReader annotationInfo = IonReaderBuilder.standard().build(constraintStruct)){
+            annotationInfo.next();
+            annotationInfo.stepIn();
+            while (annotationInfo.next() != null) {
+                if (annotationInfo.getFieldName().equals(IonSchemaUtilities.KEYWORD_ANNOTATIONS)) {
+                    IonValue annotationValue = ReadGeneralConstraints.SYSTEM.newValue(annotationInfo);
+                    List<String> constraint = Arrays.asList(annotationValue.getTypeAnnotations());
+                    IonList annotations = (IonList) annotationValue;
+                    annotationList = checkOrdered(constraint, annotations, random);
+                }
             }
-            annotationMap.put(KEYWORD_ANNOTATIONS, annotationList);
-            return annotationMap;
-        } else {
-            return null;
         }
+        return annotationList;
+    }
+
+    /**
+     * This is a helper method of getAnnotation which processes the constraint 'Ordered'.
+     * @param constraint is a List which contains all annotations of 'annotations' field.
+     * @param annotationList is the original annotation List without any consideration about constraints.
+     * @param random is a random integer generator.
+     * @return a List of processed annotations.
+     * @throws IOException if error occur when reading constraints.
+     */
+    private static IonList checkOrdered(List<String> constraint, IonList annotationList, Random random) throws IOException {
+        IonList result = annotationList;
+        if (!constraint.contains(IonSchemaUtilities.KEYWORD_ORDERED)) {
+            List<IonValue> annotations = annotationList.stream().collect(Collectors.toList());
+            Collections.shuffle(annotations);
+            try (IonReader shuffledAnnotationReader = IonReaderBuilder.standard().build(annotations.toString())) {
+                shuffledAnnotationReader.next();
+                result = (IonList) ReadGeneralConstraints.SYSTEM.newValue(shuffledAnnotationReader);
+            }
+        }
+        return checkRequired(constraint, result,random);
+    }
+
+    /**
+     * This is a helper method of getAnnotation which processes the constraint 'required'.
+     * @param constraint is a List which contains all annotations of 'annotations' field.
+     * @param annotationList is the annotation List after processing with the constraint 'ordered'.
+     * @param random is a random integer generator.
+     * @returna a List of processed annotations.
+     * @throws IOException if error occur when reading constraints.
+     */
+    private static IonList checkRequired(List<String> constraint, IonList annotationList, Random random) throws IOException {
+        IonList result = annotationList;
+        if (!constraint.contains(IonSchemaUtilities.KEYWORD_REQUIRED)) {
+            int randomValueOne = random.nextInt(annotationList.size());
+            int randomValueTwo = random.nextInt(annotationList.size());
+            List<IonValue> subAnnotationList = annotationList.subList(Math.min(randomValueOne, randomValueTwo), Math.max(randomValueOne, randomValueTwo));
+            if (subAnnotationList != null) {
+                try (IonReader annotationReader = IonReaderBuilder.standard().build(subAnnotationList.toString())) {
+                    annotationReader.next();
+                    result = (IonList) ReadGeneralConstraints.SYSTEM.newValue(annotationReader);
+                }
+            } else {
+                result = null;
+            }
+        }
+        return result;
     }
 }

--- a/src/com/amazon/ion/benchmark/ReadGeneralConstraints.java
+++ b/src/com/amazon/ion/benchmark/ReadGeneralConstraints.java
@@ -12,7 +12,6 @@ import com.amazon.ion.system.IonSystemBuilder;
 
 import java.io.BufferedInputStream;
 import java.io.FileInputStream;
-import java.util.Map;
 
 /**
  * Parse Ion Schema file and get the general constraints in the file then pass the constraints to the Ion data generator.
@@ -40,13 +39,11 @@ public class ReadGeneralConstraints {
                     IonStruct constraintStruct = (IonStruct) schemaValue;
                     // Get general constraints:
                     IonType type = IonType.valueOf(constraintStruct.get(IonSchemaUtilities.KEYWORD_TYPE).toString().toUpperCase());
-                    Map<String, Object> annotationMap = IonSchemaUtilities.getAnnotation(constraintStruct);
                     // If more types of Ion data added in the future, developers can add more types under the switch logic.
                     switch (type) {
                         case STRUCT:
                             // If more constraints relevant to Ion Struct needed to be processed, developers should call functions here.
-                            IonStruct fields = (IonStruct) constraintStruct.get(IonSchemaUtilities.KEYWORD_FIELDS);
-                            WriteRandomIonValues.writeRandomStructValues(size, format, outputFile, fields, annotationMap);
+                            WriteRandomIonValues.writeRandomStructValues(size, format, outputFile, constraintStruct);
                             break;
                         case TIMESTAMP:
                             WriteRandomIonValues.writeRandomTimestamps(size, type, outputFile, null, format);
@@ -71,7 +68,7 @@ public class ReadGeneralConstraints {
                             WriteRandomIonValues.writeRandomSymbolValues(size, format, outputFile);
                             break;
                         case LIST:
-                            WriteRandomIonValues.writeRandomListValues(size, format, outputFile, constraintStruct, annotationMap);
+                            WriteRandomIonValues.writeRandomListValues(size, format, outputFile, constraintStruct);
                             break;
                         default:
                             throw new IllegalStateException(type + " is not supported when generating IonValue based on Ion Schema.");

--- a/src/com/amazon/ion/benchmark/WriteRandomIonValues.java
+++ b/src/com/amazon/ion/benchmark/WriteRandomIonValues.java
@@ -15,7 +15,6 @@ package com.amazon.ion.benchmark;
  * permissions and limitations under the License.
  */
 
-
 import com.amazon.ion.IonList;
 import com.amazon.ion.IonReader;
 import com.amazon.ion.IonStruct;
@@ -39,10 +38,7 @@ import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Random;
-import java.util.Set;
-
 
 /**
  * Generate specific scalar type of Ion data randomly, for some specific type, e.g. String, Decimal, Timestamp, users can put specifications on these types of Ion data.
@@ -56,8 +52,6 @@ class WriteRandomIonValues {
     final static private List<Integer> NO_EXPONENT_VALUE_RANGE = null;
     final static private List<Integer> NO_COEFFICIENT_DIGIT_RANGE = null;
     final static private String NO_TIMESTAMP_TEMPLATE = null;
-    final static private IonStruct NO_FIELDS = null;
-    final static private Map<String, Object> NO_ANNOTATION_MAP = null;
     final static private IonStruct NO_CONSTRAINT_STRUCT = null;
 
     /**
@@ -122,9 +116,6 @@ class WriteRandomIonValues {
         }
     }
 
-    private static void organizeInputParameter(Set<String> requiredParameters){
-
-    }
     /**
      * Write random Ion strings into target file, and all data conform with the specifications provided by the options if these are provided. Otherwise, this method will generate Ion string data randomly.
      * @param size specifies the size in bytes of the generated file.
@@ -142,7 +133,7 @@ class WriteRandomIonValues {
 
             if (pointRange.get(0) < 0) throw new IllegalStateException("Please provide the valid range inside of [0, 1114111]");
             if (pointRange.get(1) > Character.MAX_CODE_POINT) throw new IllegalStateException("Please provide the valid range inside of [0, 1114111]");
-            WriteRandomIonValues.writeRequestedSizeFile(size, writer, file, type, codePointLength, pointRange, NO_EXPONENT_VALUE_RANGE, NO_COEFFICIENT_DIGIT_RANGE, NO_TIMESTAMP_TEMPLATE, NO_FIELDS, NO_ANNOTATION_MAP, NO_CONSTRAINT_STRUCT);
+            WriteRandomIonValues.writeRequestedSizeFile(size, writer, file, type, codePointLength, pointRange, NO_EXPONENT_VALUE_RANGE, NO_COEFFICIENT_DIGIT_RANGE, NO_TIMESTAMP_TEMPLATE, NO_CONSTRAINT_STRUCT);
         }
         WriteRandomIonValues.printInfo(path);
     }
@@ -164,7 +155,7 @@ class WriteRandomIonValues {
             List<Integer> expValRange = WriteRandomIonValues.parseRange(expRange);
             List<Integer> coefficientDigitRange = WriteRandomIonValues.parseRange(coefficientDigit);
             if (coefficientDigitRange.get(0) <= 0) throw new IllegalStateException ("The coefficient digits should be positive integer");
-            WriteRandomIonValues.writeRequestedSizeFile(size, writer, file, type, NO_CODE_POINT_LENGTH, NO_POINT_RANGE, expValRange, coefficientDigitRange, NO_TIMESTAMP_TEMPLATE, NO_FIELDS, NO_ANNOTATION_MAP, NO_CONSTRAINT_STRUCT);
+            WriteRandomIonValues.writeRequestedSizeFile(size, writer, file, type, NO_CODE_POINT_LENGTH, NO_POINT_RANGE, expValRange, coefficientDigitRange, NO_TIMESTAMP_TEMPLATE, NO_CONSTRAINT_STRUCT);
         }
         WriteRandomIonValues.printInfo(path);
     }
@@ -180,7 +171,7 @@ class WriteRandomIonValues {
     public static void writeRandomInts(int size, IonType type, String format, String path) throws Exception {
         File file = new File(path);
         try (IonWriter writer = WriteRandomIonValues.formatWriter(format, file)) {
-           WriteRandomIonValues.writeRequestedSizeFile(size, writer, file, type, NO_CODE_POINT_LENGTH, NO_POINT_RANGE, NO_EXPONENT_VALUE_RANGE, NO_COEFFICIENT_DIGIT_RANGE, NO_TIMESTAMP_TEMPLATE, NO_FIELDS, NO_ANNOTATION_MAP, NO_CONSTRAINT_STRUCT);
+           WriteRandomIonValues.writeRequestedSizeFile(size, writer, file, type, NO_CODE_POINT_LENGTH, NO_POINT_RANGE, NO_EXPONENT_VALUE_RANGE, NO_COEFFICIENT_DIGIT_RANGE, NO_TIMESTAMP_TEMPLATE, NO_CONSTRAINT_STRUCT);
         }
         WriteRandomIonValues.printInfo(path);
     }
@@ -196,7 +187,7 @@ class WriteRandomIonValues {
     public static void writeRandomFloats(int size, IonType type, String format, String path) throws Exception {
         File file = new File(path);
         try (IonWriter writer = WriteRandomIonValues.formatWriter(format, file)) {
-            WriteRandomIonValues.writeRequestedSizeFile(size, writer, file, type, NO_CODE_POINT_LENGTH, NO_POINT_RANGE, NO_EXPONENT_VALUE_RANGE, NO_COEFFICIENT_DIGIT_RANGE, NO_TIMESTAMP_TEMPLATE, NO_FIELDS, NO_ANNOTATION_MAP, NO_CONSTRAINT_STRUCT);
+            WriteRandomIonValues.writeRequestedSizeFile(size, writer, file, type, NO_CODE_POINT_LENGTH, NO_POINT_RANGE, NO_EXPONENT_VALUE_RANGE, NO_COEFFICIENT_DIGIT_RANGE, NO_TIMESTAMP_TEMPLATE, NO_CONSTRAINT_STRUCT);
         }
         WriteRandomIonValues.printInfo(path);
     }
@@ -289,7 +280,7 @@ class WriteRandomIonValues {
     public static void writeRandomTimestamps(int size, IonType type, String path, String timestampTemplate, String format) throws Exception {
         File file = new File(path);
         try (IonWriter writer = WriteRandomIonValues.formatWriter(format, file)) {
-            WriteRandomIonValues.writeRequestedSizeFile(size, writer, file, type, NO_CODE_POINT_LENGTH, NO_POINT_RANGE, NO_EXPONENT_VALUE_RANGE, NO_COEFFICIENT_DIGIT_RANGE, timestampTemplate, NO_FIELDS, NO_ANNOTATION_MAP, NO_CONSTRAINT_STRUCT);
+            WriteRandomIonValues.writeRequestedSizeFile(size, writer, file, type, NO_CODE_POINT_LENGTH, NO_POINT_RANGE, NO_EXPONENT_VALUE_RANGE, NO_COEFFICIENT_DIGIT_RANGE, timestampTemplate, NO_CONSTRAINT_STRUCT);
         }
         WriteRandomIonValues.printInfo(path);
     }
@@ -487,25 +478,23 @@ class WriteRandomIonValues {
      * @param expValRange the range of exponent when the decimal represented in coefficient * 10 ^ exponent.
      * @param coefficientDigitRange the range of digit number of coefficient when the decimal represented in coefficient * 10 ^ exponent.
      * @param timestampTemplate  is a string which provides a series of template timestamps which data generating process will follow with.
-     * @param fields is an Ion struct which contains the constraints needed during the data generating process.
-     * @param annotationMap contains the information of annotations, both the constraint of the annotation and the value of the annotation.
      * @param constraintStruct is an IonStruct which contains the top-level constraints in Ion Schema.
      * @throws IOException if an error occur when writing generated data.
      */
-    public static void writeRequestedSizeFile(int size, IonWriter writer, File file, IonType type, int codePointLength, List<Integer> pointRange, List<Integer> expValRange, List<Integer> coefficientDigitRange, String timestampTemplate, IonStruct fields, Map<String, Object> annotationMap, IonStruct constraintStruct) throws Exception {
+    public static void writeRequestedSizeFile(int size, IonWriter writer, File file, IonType type, int codePointLength, List<Integer> pointRange, List<Integer> expValRange, List<Integer> coefficientDigitRange, String timestampTemplate, IonStruct constraintStruct) throws Exception {
         Random random = new Random();
         int currentSize = 0;
         int count = 0;
         // Determine how many values should be write before the writer.flush()
         while (currentSize <= 0.05 * size) {
-            WriteRandomIonValues.writeDataToFile(type, writer, random, codePointLength, pointRange, expValRange, coefficientDigitRange, timestampTemplate, fields, annotationMap, constraintStruct);
+            WriteRandomIonValues.writeDataToFile(type, writer, random, codePointLength, pointRange, expValRange, coefficientDigitRange, timestampTemplate, constraintStruct);
             count += 1;
             writer.flush();
             currentSize = (int) file.length();
         }
         while (currentSize <= size) {
             for (int i = 0; i < count; i++) {
-                WriteRandomIonValues.writeDataToFile(type, writer, random, codePointLength, pointRange, expValRange, coefficientDigitRange, timestampTemplate, fields, annotationMap, constraintStruct);
+                WriteRandomIonValues.writeDataToFile(type, writer, random, codePointLength, pointRange, expValRange, coefficientDigitRange, timestampTemplate, constraintStruct);
             }
             writer.flush();
             currentSize = (int) file.length();
@@ -522,13 +511,11 @@ class WriteRandomIonValues {
      * @param expValRange the range of exponent when the decimal represented in coefficient * 10 ^ exponent.
      * @param coefficientDigitRange the range of digit number of coefficient when the decimal represented in coefficient * 10 ^ exponent.
      * @param timestampTemplate  is a string which provides a series of template timestamps which data generating process will follow with.
-     * @param fields is an Ion Struct which contains the constraints needed during the data generating process.
-     * @param annotationMap contains the information of annotations, both the constraint of the annotation and the value of the annotation.
      * @param constraintStruct is an IonStruct which contains the top-level constraints in Ion Schema.
      * @throws IOException if an error occur during the data writing process.
      */
-    private static void writeDataToFile(IonType type, IonWriter writer, Random random, int codePointLength, List<Integer> pointRange, List<Integer> expValRange, List<Integer> coefficientDigitRange, String timestampTemplate, IonStruct fields, Map<String, Object> annotationMap, IonStruct constraintStruct) throws Exception {
-        IonValue annotation = null;
+    private static void writeDataToFile(IonType type, IonWriter writer, Random random, int codePointLength, List<Integer> pointRange, List<Integer> expValRange, List<Integer> coefficientDigitRange, String timestampTemplate, IonStruct constraintStruct) throws Exception {
+        IonList annotationList;
         switch (type) {
             case FLOAT:
                 WriteRandomIonValues.constructFloat(writer, random);
@@ -548,33 +535,12 @@ class WriteRandomIonValues {
                 writer.writeTimestamp(timestamp);
                 break;
             case STRUCT:
-                if (annotationMap != null) {
-                    String annotationConstraint = annotationMap.get(IonSchemaUtilities.KEYWORD_CONSTRAINT).toString();
-                    IonList annotationList = (IonList) annotationMap.get(IonSchemaUtilities.KEYWORD_ANNOTATIONS);
-                    if (annotationConstraint.equals(IonSchemaUtilities.KEYWORD_REQUIRED)) {
-                        for (int i = 0; i < annotationList.size(); i++) {
-                            int index = random.nextInt(annotationMap.size());
-                            annotation = annotationList.get(index);
-                            WriteRandomIonValues.constructIonStruct(fields, annotation, writer);
-                        }
-                    } else if (annotationConstraint.equals(IonSchemaUtilities.KEYWORD_ORDERED)) {
-                        for (int index = 0; index < annotationList.size(); index++) {
-                            annotation = annotationList.get(index);
-                            WriteRandomIonValues.constructIonStruct(fields, annotation, writer);
-                        }
-                    } else {
-                        int index = random.nextInt(annotationList.size() + 1);
-                        if (index != annotationList.size()) {
-                            annotation = annotationList.get(index);
-                        }
-                        WriteRandomIonValues.constructIonStruct(fields, annotation, writer);
-                    }
-                } else {
-                    WriteRandomIonValues.constructIonStruct(fields, annotation, writer);
-                }
+                annotationList = IonSchemaUtilities.getAnnotation(constraintStruct);
+                WriteRandomIonValues.constructIonStruct(constraintStruct, annotationList, writer);
                 break;
             case LIST:
-                WriteRandomIonValues.constructIonList(writer, constraintStruct);
+                annotationList = IonSchemaUtilities.getAnnotation(constraintStruct);
+                WriteRandomIonValues.constructIonList(writer, constraintStruct, annotationList);
                 break;
         }
     }
@@ -697,33 +663,33 @@ class WriteRandomIonValues {
      * @param format is the format of the generated file, select from set (ion_text | ion_binary).
      * @param size specifies the size in bytes of the generated file.
      * @param path the destination of the generated file.
-     * @param fields is an Ion struct which contains the constraints needed during data generating process.
-     * @param annotationMap contains the information of annotations, both the constraint of the annotation and the value of the annotation.
+     * @param constraintStruct is an IonStruct which contains the top-level constraints in Ion Schema.
      * @throws Exception if errors occur when writing data.
      */
-    public static void writeRandomStructValues(int size, String format, String path, IonStruct fields, Map<String, Object> annotationMap) throws Exception {
+    public static void writeRandomStructValues(int size, String format, String path, IonStruct constraintStruct) throws Exception {
         File file = new File(path);
         IonType type = IonType.STRUCT;
         try (IonWriter writer = WriteRandomIonValues.formatWriter(format, file)) {
-            WriteRandomIonValues.writeRequestedSizeFile(size, writer, file, type, NO_CODE_POINT_LENGTH, NO_POINT_RANGE, NO_EXPONENT_VALUE_RANGE, NO_COEFFICIENT_DIGIT_RANGE, NO_TIMESTAMP_TEMPLATE, fields, annotationMap, NO_CONSTRAINT_STRUCT);
+            WriteRandomIonValues.writeRequestedSizeFile(size, writer, file, type, NO_CODE_POINT_LENGTH, NO_POINT_RANGE, NO_EXPONENT_VALUE_RANGE, NO_COEFFICIENT_DIGIT_RANGE, NO_TIMESTAMP_TEMPLATE, constraintStruct);
             WriteRandomIonValues.printInfo(path);
         }
     }
 
     /**
      * Construct Ion structs based on the provided constraints.
-     * @param fields is an Ion struct which contains the constraints needed during the data generating process.
-     * @param annotation is an IonValue represents the value of annotation.
+     * @param constraintStruct is an IonStruct which contains the top-level constraints in Ion Schema.
+     * @param annotations is an IonList represents the value of annotations.
      * @param writer writes Ion struct data.
      * @throws IOException if errors occur when writing data.
      */
-    public static void constructIonStruct(IonStruct fields, IonValue annotation, IonWriter writer) throws IOException {
+    public static void constructIonStruct(IonStruct constraintStruct, IonList annotations, IonWriter writer) throws IOException {
         Random random = new Random();
+        IonStruct fields = (IonStruct) constraintStruct.get(IonSchemaUtilities.KEYWORD_FIELDS);
         try (IonReader reader = IonReaderBuilder.standard().build(fields)) {
             reader.next();
             reader.stepIn();
-            if (annotation != null) {
-                writer.addTypeAnnotation(String.valueOf(annotation));
+            for (int i = 0; i < annotations.size(); i++) {
+                writer.addTypeAnnotation(annotations.get(i).toString());
             }
             writer.stepIn(IonType.STRUCT);
             while (reader.next() != null) {
@@ -770,38 +736,42 @@ class WriteRandomIonValues {
      * @param format is the format of the generated file, select from set (ion_text | ion_binary).
      * @param path the destination of the generated file.
      * @param constraintStruct is an IonStruct which contains the top-level constraints in Ion Schema.
-     * @param annotations contains the information of annotations, both the constraint of the annotation and the value of the annotation.
      * @throws Exception if errors occur when writing data.
      */
-    public static void writeRandomListValues(int size, String format, String path, IonStruct constraintStruct, Map <String, Object> annotations) throws Exception {
+    public static void writeRandomListValues(int size, String format, String path, IonStruct constraintStruct) throws Exception {
         File file = new File(path);
         IonType type = IonType.LIST;
         try (IonWriter writer = WriteRandomIonValues.formatWriter(format, file)) {
-            WriteRandomIonValues.writeRequestedSizeFile(size, writer, file, type, NO_CODE_POINT_LENGTH, NO_POINT_RANGE, NO_EXPONENT_VALUE_RANGE, NO_COEFFICIENT_DIGIT_RANGE, NO_TIMESTAMP_TEMPLATE, NO_FIELDS, NO_ANNOTATION_MAP, constraintStruct);
+            WriteRandomIonValues.writeRequestedSizeFile(size, writer, file, type, NO_CODE_POINT_LENGTH, NO_POINT_RANGE, NO_EXPONENT_VALUE_RANGE, NO_COEFFICIENT_DIGIT_RANGE, NO_TIMESTAMP_TEMPLATE, constraintStruct);
             WriteRandomIonValues.printInfo(path);
         }
     }
 
     /**
-     * Construct Ion List based on the constraints in Ion Schema.
+     * Construct Ion List based on the constraints provided by Ion Schema.
      * @param writer is Ion Writer.
      * @param constraints is an IonStruct which contains the top-level constraints in Ion Schema.
+     * @param annotationList  is an IonList represents the value of annotations.
      * @throws Exception if errors occur when reading or writing data.
      */
-    public static void constructIonList(IonWriter writer, IonStruct constraints) throws Exception {
+    public static void constructIonList(IonWriter writer, IonStruct constraints, IonList annotationList) throws Exception {
         // When there's only one required element in Ion List and the length of generated Ion List is not specified, we set the default length as a integer smaller than 20.
-        Random random = new Random();
-        int listSize = random.nextInt(20);
+        int containerLength = IonSchemaUtilities.parseConstraints(constraints, IonSchemaUtilities.KEYWORD_CONTAINER_LENGTH);
         int occurrences;
         try (IonReader reader = IonReaderBuilder.standard().build(constraints)) {
             reader.next();
             reader.stepIn();
             while (reader.next() != null) {
+                if (annotationList != null) {
+                    for (int i = 0; i < annotationList.size(); i++) {
+                        writer.addTypeAnnotation(annotationList.get(i).toString());
+                    }
+                }
                 writer.stepIn(IonType.LIST);
                 // If constraint name is 'element', only one type of Ion Data is specified.
                 if (constraints.get(IonSchemaUtilities.KEYWORD_ELEMENT) != null) {
                     IonType type = IonType.valueOf(constraints.get(IonSchemaUtilities.KEYWORD_ELEMENT).toString().toUpperCase());
-                    for (int i = 0; i < listSize; i++) {
+                    for (int i = 0; i < containerLength; i++) {
                         occurrences = 1;
                         WriteRandomIonValues.constructScalarTypeData(type, writer, occurrences);
                     }

--- a/tst/com/amazon/ion/benchmark/testStruct.isl
+++ b/tst/com/amazon/ion/benchmark/testStruct.isl
@@ -3,7 +3,7 @@
  type::{
       name: Customer,
       type: struct,
-      Annotations:[corporate, gold_class, club_member],
+      annotations:[corporate, gold_class, club_member],
       fields: {
         firstName: { type: string, occurs: required },
         lastName: { type: string, occurs: optional },


### PR DESCRIPTION
*Description of changes:*
This PR updates the method of parsing annotation constraint, and change the original constant container_length to a variable which can be extracted from Ion Schema when generating Ion List.

Review guide:
IonSchemaUtilities.java:
- Line 70-78:  When parse the constraint 'container_length', the format [min, 100] might be provided, and in this case the type of lower bound value is Ion Symbol and it represent integer 0, when the format [10, max] provided, max value represents Integer.MAX_VALUE.

- Method getAnnotation( ):  Before update, this method will return a hash map which contains all information about constraint 'annotations'. After reorganization, this method will return an Ion List which contains all annotations that will be assigned to one Ion Value. First of all, this method will check whether the annotation of this constraint contain keyword 'ordered'(annotations:ordered::required::[value1, value2]), and it will check whether the annotations of this constraint contain 'required'. More details about Ion Schema [general constraint](https://amzn.github.io/ion-schema/docs/spec.html#annotations). After these steps, the final annotations assigned to one Ion Value will be passed to method constructIonStruct/constrauctIonList.

- ReadGeneralConstraints.java:  When calling the method that generating Ion Struct, instead of passing annotations as a parameter, this annotation constraint will be extracted during the writing data process. This way avoiding passing the parameter that will not be used under the current method and also avoid the duplicated information that is already contained in the other parameter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
