### PR TITLE
Changes the name of generated benchmark results to comform with the sequence of building ion-java.

### DIFF
--- a/src/com/amazon/ion/benchmark/GenerateAndOrganizeBenchmarkResults.java
+++ b/src/com/amazon/ion/benchmark/GenerateAndOrganizeBenchmarkResults.java
@@ -41,7 +41,7 @@ public class GenerateAndOrganizeBenchmarkResults {
         // Get the version of ion-java-benchmark-cli-jar-with-dependencies.jar
         String version = parseVersionFromPom(POM_FILE);
         String ionJavaBenchmarkInvoke = ION_JAVA_BENCHMARK_INVOKE_ELEMENT + version + JAR_WITH_DEPENDENCIES;
-        String fileName = PREVIOUS_FILE;
+        String fileName = NEW_FILE;
         String makeFinalDirectoryCommand = MAKE_DIRECTORY + finalResultDirectory;
         IonList optionsCombinationsList;
         try (IonReader reader = IonReaderBuilder.standard().build(new BufferedInputStream(new FileInputStream(combinations)))) {
@@ -66,7 +66,7 @@ public class GenerateAndOrganizeBenchmarkResults {
                 // When generating benchmark results for ion-java from the new commit, all benchmark results will be named as 'new.ion'.
                 File fileCheck = new File(finalResultDirectory + subDirectoryName + File.separator + fileName);
                 if (fileCheck.exists()) {
-                    fileName = NEW_FILE;
+                    fileName = PREVIOUS_FILE;
                 }
                 // Execute ion-java-benchmark invoke.
                 String commandLine = ionJavaBenchmarkInvoke + benchmarkOptionCombination + "--results-file " +  finalResultDirectory + subDirectoryName + File.separator + fileName + " " + testData.getAbsolutePath();


### PR DESCRIPTION
**Motivation:**

In the GitHub workflow which can automatically detect the ion-java performance regression, we swapped the sequence of building ion-java. In this case, we need to change the benchmark result name as well. The first build of ion-java is from the new commit, then the generated benchmark result should be named as 'new.ion', the following generated benchmark result should be named as 'previous.ion' which is generated by benchmark the ion-java from the previous commit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
