### PR TITLE
Updates the method of generating timestamps to fix the bug.

### DIFF
--- a/tst/com/amazon/ion/benchmark/DataGeneratorTest.java
+++ b/tst/com/amazon/ion/benchmark/DataGeneratorTest.java
@@ -212,7 +212,7 @@ public class DataGeneratorTest {
      */
     @Test
     public void testGeneratedTimestampTemplateFormat() throws Exception{
-        Map<String, Object> optionsMap = Main.parseArguments("generate", "--data-size", "500", "--data-type", "timestamp", "--timestamps-template", "[2021T]", "test6.10n");
+        Map<String, Object> optionsMap = Main.parseArguments("generate", "--data-size", "500", "--data-type", "timestamp", "--timestamps-template", "[2021T, 2021-03T]", "--format", "ion_text", "test6.10n");
         try (
                 IonReader reader = DataGeneratorTest.executeAndRead(optionsMap);
                 IonReader templateReader = IonReaderBuilder.standard().build(optionsMap.get("--timestamps-template").toString())


### PR DESCRIPTION
**Motivation:**

- **Issue:**

  - When providing a list of timestamp-template, the generated timestamps only conform with the last timestamp in the template, because the iteration of timestamp template was located inside of the method 'constructTimestamp' which will only return one format of timestamp to the writing process.

- **Steps to fix it:** 

  - In order to fix this, the iteration of timestamp template should be located in the process of writing data to the generated file process. In this way, every timestamp in the template will be used to constructing timestamps.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
