### PR TITLE
Enables the --ion-reader option for comparing binary reader implementations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@
         <dependency>
             <groupId>com.amazon.ion</groupId>
             <artifactId>ion-java</artifactId>
-            <!-- Take the latest version that is at least 1.6.1. -->
-            <version>[1.6.1,)</version>
+            <!-- Take the latest version that is at least 1.9.0. -->
+            <version>[1.9.0,)</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/com/amazon/ion/benchmark/Bench.java
+++ b/src/com/amazon/ion/benchmark/Bench.java
@@ -7,10 +7,10 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
 
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.util.concurrent.Callable;
 
 /**
  * JMH benchmark for a single options combination.
@@ -31,7 +31,7 @@ public class Bench {
     private String options;
 
     MeasurableTask measurableTask = null;
-    Callable<Void> taskToMeasure = null;
+    MeasurableTask.Task taskToMeasure = null;
 
     @Setup(Level.Trial)
     public void setUpTrial() throws Exception {
@@ -57,7 +57,7 @@ public class Bench {
     }
 
     @Benchmark
-    public void run() throws Exception {
-        taskToMeasure.call();
+    public void run(Blackhole blackhole) throws Exception {
+        taskToMeasure.run(new BlackholeSideEffectConsumer(blackhole));
     }
 }

--- a/src/com/amazon/ion/benchmark/BlackholeSideEffectConsumer.java
+++ b/src/com/amazon/ion/benchmark/BlackholeSideEffectConsumer.java
@@ -1,0 +1,42 @@
+package com.amazon.ion.benchmark;
+
+import org.openjdk.jmh.infra.Blackhole;
+
+public class BlackholeSideEffectConsumer implements SideEffectConsumer {
+
+    private final Blackhole blackhole;
+
+    BlackholeSideEffectConsumer(Blackhole blackhole) {
+        this.blackhole = blackhole;
+    }
+
+    @Override
+    public void consume(boolean b) {
+        blackhole.consume(b);
+    }
+
+    @Override
+    public void consume(int i) {
+        blackhole.consume(i);
+    }
+
+    @Override
+    public void consume(long l) {
+        blackhole.consume(l);
+    }
+
+    @Override
+    public void consume(float f) {
+        blackhole.consume(f);
+    }
+
+    @Override
+    public void consume(double d) {
+        blackhole.consume(d);
+    }
+
+    @Override
+    public void consume(Object o) {
+        blackhole.consume(o);
+    }
+}

--- a/src/com/amazon/ion/benchmark/IonMeasurableReadTask.java
+++ b/src/com/amazon/ion/benchmark/IonMeasurableReadTask.java
@@ -1,5 +1,6 @@
 package com.amazon.ion.benchmark;
 
+import com.amazon.ion.IonBufferConfiguration;
 import com.amazon.ion.IonReader;
 import com.amazon.ion.IonSystem;
 import com.amazon.ion.IonType;
@@ -51,9 +52,8 @@ class IonMeasurableReadTask extends MeasurableReadTask {
     IonMeasurableReadTask(Path inputPath, ReadOptionsCombination options) throws IOException {
         super(inputPath, options);
         ionSystem = IonUtilities.ionSystemForBenchmark(options);
-        readerBuilder = IonUtilities.newReaderBuilderForBenchmark(options)/*.
-            withIncrementalReadingEnabled(options.readerType == IonReaderType.INCREMENTAL)*/;
-        /*
+        readerBuilder = IonUtilities.newReaderBuilderForBenchmark(options).
+            withIncrementalReadingEnabled(options.readerType == IonReaderType.INCREMENTAL);
         if (readerBuilder.isIncrementalReadingEnabled()) {
             if (options.initialBufferSize != null) {
                 readerBuilder.withBufferConfiguration(
@@ -68,7 +68,6 @@ class IonMeasurableReadTask extends MeasurableReadTask {
                 }
             }
         }
-         */
         if (options.paths != null) {
             PathExtractorBuilder<?> pathExtractorBuilder = PathExtractorBuilder.standard();
             for (String path : options.paths) {

--- a/src/com/amazon/ion/benchmark/Main.java
+++ b/src/com/amazon/ion/benchmark/Main.java
@@ -38,8 +38,8 @@ public class Main {
             + "[--results-file <file>] [--io-type <type>]... [--io-buffer-size <int>]... [--format <type>]... "
             + "[--api <api>]... [--ion-imports-for-input <file>] [--ion-imports-for-benchmark <file>]... "
             + "[--ion-flush-period <int>]... [--ion-length-preallocation <int>]... [--ion-float-width <int>]... "
-            + "[--ion-use-symbol-tokens <bool>]... [--paths <file>] "
-            + "[--ion-use-lob-chunks <bool>]... [--ion-use-big-decimals <bool>]..."
+            + "[--ion-use-symbol-tokens <bool>]... [--paths <file>] [--ion-reader <type>]... "
+            + "[--ion-use-lob-chunks <bool>]... [--ion-use-big-decimals <bool>]... [--ion-reader-buffer-size <int>]... "
             + "[--json-use-big-decimals <bool>]... <input_file>\n"
         
         + "  ion-java-benchmark generate (--data-size <data_size>) [--data-type <data_type>] "
@@ -224,6 +224,11 @@ public class Main {
             + "formats, the most efficient known API for performing sparse reads will be used. Ignored unless "
             + "--ion-api streaming is specified. By default, no search paths will be used, meaning the input data "
             + "will be fully traversed and materialized.)\n"
+
+        + "  -R --ion-reader <type>                 The IonReader type to use, from the set (incremental | "
+            + "non_incremental). May be specified multiple times to compare different readers. Note: because the DOM "
+            + "uses IonReader to parse data, this option is applicable for read benchmarks with both options for "
+            + "--ion-api. Ignored unless --format is ion_binary. [default: incremental]\n"
 
         + "  -e --ion-use-lob-chunks <bool>         When true, read Ion blobs and clobs in chunks into a reusable "
             + "buffer of size 1024 bytes using `IonReader.getBytes`. When false, use `IonReader.newBytes`, which "

--- a/src/com/amazon/ion/benchmark/MeasurableTask.java
+++ b/src/com/amazon/ion/benchmark/MeasurableTask.java
@@ -1,12 +1,16 @@
 package com.amazon.ion.benchmark;
 
 import java.io.IOException;
-import java.util.concurrent.Callable;
 
 /**
  * A task to benchmark.
  */
 public interface MeasurableTask {
+
+    @FunctionalInterface
+    interface Task {
+        void run(SideEffectConsumer consumer) throws Exception;
+    }
 
     /**
      * Set up the trial, which is the complete set of iterations.
@@ -35,5 +39,5 @@ public interface MeasurableTask {
     /**
      * @return the piece of code to benchmark.
      */
-    Callable<Void> getTask();
+    Task getTask();
 }

--- a/src/com/amazon/ion/benchmark/OptionsMatrixBase.java
+++ b/src/com/amazon/ion/benchmark/OptionsMatrixBase.java
@@ -18,7 +18,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -472,11 +471,11 @@ abstract class OptionsMatrixBase {
             OptionsCombinationBase options = OptionsCombinationBase.from(serializedOptionsCombinations[0]);
             MeasurableTask measurableTask = options.createMeasurableTask(Paths.get(inputFile));
             measurableTask.setUpTrial();
-            Callable<Void> task = measurableTask.getTask();
+            MeasurableTask.Task task = measurableTask.getTask();
             System.out.println("Entering profiling mode. Type q (followed by Enter/Return) to terminate after the next complete iteration.");
             while (System.in.available() <= 0 || System.in.read() != 'q') {
                 measurableTask.setUpIteration();
-                task.call();
+                task.run(SideEffectConsumer.NO_OP);
                 measurableTask.tearDownIteration();
             }
             measurableTask.tearDownTrial();

--- a/src/com/amazon/ion/benchmark/ReadOptionsMatrix.java
+++ b/src/com/amazon/ion/benchmark/ReadOptionsMatrix.java
@@ -44,7 +44,6 @@ class ReadOptionsMatrix extends OptionsMatrixBase {
                 }
             );
         }
-        /*
         parseAndCombine(
             optionsMatrix.get("--ion-reader"),
             ION_READER_NAME,
@@ -54,7 +53,6 @@ class ReadOptionsMatrix extends OptionsMatrixBase {
             OptionsMatrixBase::noImplicitDefault,
             OPTION_ONLY_APPLIES_TO_ION_BINARY
         );
-         */
         parseAndCombine(
             optionsMatrix.get("--ion-use-lob-chunks"),
             ION_USE_LOB_CHUNKS_NAME,
@@ -73,7 +71,6 @@ class ReadOptionsMatrix extends OptionsMatrixBase {
             () -> ION_SYSTEM.newBool(false),
             OPTION_ONLY_APPLIES_TO_ION_STREAMING
         );
-        /*
         parseAndCombine(
             optionsMatrix.get("--ion-reader-buffer-size"),
             ION_READER_BUFFER_SIZE_NAME,
@@ -87,7 +84,6 @@ class ReadOptionsMatrix extends OptionsMatrixBase {
                     IonReaderType.INCREMENTAL.name().equals(getStringValue(struct, ION_READER_NAME));
             }
         );
-         */
     }
 
 }

--- a/src/com/amazon/ion/benchmark/SideEffectConsumer.java
+++ b/src/com/amazon/ion/benchmark/SideEffectConsumer.java
@@ -1,0 +1,44 @@
+package com.amazon.ion.benchmark;
+
+interface SideEffectConsumer {
+
+    SideEffectConsumer NO_OP = new SideEffectConsumer() {
+
+        @Override
+        public void consume(boolean b) {
+            // Do nothing.
+        }
+
+        @Override
+        public void consume(int i) {
+            // Do nothing.
+        }
+
+        @Override
+        public void consume(long l) {
+            // Do nothing.
+        }
+
+        @Override
+        public void consume(float f) {
+            // Do nothing.
+        }
+
+        @Override
+        public void consume(double d) {
+            // Do nothing.
+        }
+
+        @Override
+        public void consume(Object o) {
+            // Do nothing.
+        }
+    };
+
+    void consume(boolean b);
+    void consume(int i);
+    void consume(long l);
+    void consume(float f);
+    void consume(double d);
+    void consume(Object o);
+}

--- a/tst/com/amazon/ion/benchmark/OptionsTest.java
+++ b/tst/com/amazon/ion/benchmark/OptionsTest.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
-import java.util.concurrent.Callable;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -392,9 +391,9 @@ public class OptionsTest {
             assertImportsEqual(optionsCombination.importsForBenchmarkFile, streamBytes);
         }
         // Ensure that the task executes without error.
-        Callable<Void> callable = task.getTask();
+        MeasurableTask.Task callable = task.getTask();
         task.setUpIteration();
-        callable.call();
+        callable.run(SideEffectConsumer.NO_OP);
         task.tearDownIteration();
         task.tearDownTrial();
         if (isConversionRequired && optionsCombination.ioType == IoType.FILE) {
@@ -435,7 +434,7 @@ public class OptionsTest {
             assertEquals(expectedOutputFormat, Format.classify(task.inputFile.toPath()));
         }
         // Ensure that the task executes without error.
-        Callable<Void> callable = task.getTask();
+        MeasurableTask.Task callable = task.getTask();
         task.setUpIteration();
         if (expectedIoType == IoType.FILE) {
             assertTrue(task.currentFile.exists());
@@ -445,7 +444,7 @@ public class OptionsTest {
             // No preparation is needed for the buffer.
             assertNull(task.currentBuffer);
         }
-        callable.call();
+        callable.run(SideEffectConsumer.NO_OP);
         File outputFile = null;
         byte[] outputBytes;
         if (expectedIoType == IoType.FILE) {

--- a/tst/com/amazon/ion/benchmark/OptionsTest.java
+++ b/tst/com/amazon/ion/benchmark/OptionsTest.java
@@ -923,8 +923,8 @@ public class OptionsTest {
             importsV2FileName,
             "--ion-imports-for-benchmark",
             "none",
-            //"--ion-reader",
-            //"non_incremental",
+            "--ion-reader",
+            "non_incremental",
             "--ion-use-symbol-tokens",
             "true",
             "binaryStructsWithImports.10n"
@@ -1193,7 +1193,6 @@ public class OptionsTest {
         assertTrue(expectedCombinations.isEmpty());
     }
 
-    @Ignore
     @Test
     public void readAllTypes() throws Exception {
         List<ReadOptionsCombination> optionsCombinations = parseOptionsCombinations(
@@ -1361,7 +1360,6 @@ public class OptionsTest {
         assertTrue(expectedCombinations.isEmpty());
     }
 
-    @Ignore
     @Test
     public void readWithCustomIncrementalBufferSize() throws Exception {
         List<ReadOptionsCombination> optionsCombinations = parseOptionsCombinations(


### PR DESCRIPTION
*Issue #, if available:*
Fixes #4 

*Description of changes:*

* Re-enables the `--ion-reader` option, which allows the user to benchmark the new incremental reader implementation, now that that implementation has been released in ion-java 1.9.0. For the full diff that added this option (originally called non_blocking instead of incremental), see [this commit](https://github.com/amzn/ion-java-benchmark-cli/commit/bfddeaad0bef3ecd51042e604f861c489ac35ee6). 
* Uses Blackhole to avoid optimizations that could result in inaccurate results.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
