### PR TITLE
Adds new features to Ion Data Generator to process constraints of Timestamp, Clob/Blob and Decimal.

### DIFF
--- a/src/com/amazon/ion/benchmark/GeneratorOptions.java
+++ b/src/com/amazon/ion/benchmark/GeneratorOptions.java
@@ -32,6 +32,7 @@ public class GeneratorOptions {
         }
         if (optionsMap.get("--input-ion-schema") != null) {
             String inputFilePath = optionsMap.get("--input-ion-schema").toString();
+            IonSchemaUtilities.checkValidationOfSchema(inputFilePath);
             ReadGeneralConstraints.readIonSchemaAndGenerate(size, inputFilePath, format, path);
         } else if (optionsMap.get("--data-type") != null) {
             IonType type = IonType.valueOf(optionsMap.get("--data-type").toString().toUpperCase());
@@ -55,7 +56,7 @@ public class GeneratorOptions {
                     break;
                 case BLOB:
                 case CLOB:
-                    WriteRandomIonValues.writeRandomLobs(size, type, format, path);
+                    WriteRandomIonValues.writeRandomLobs(size, type, format, path, WriteRandomIonValues.NO_CONSTRAINT_STRUCT);
                     break;
                 case SYMBOL:
                     WriteRandomIonValues.writeRandomSymbolValues(size, format, path);

--- a/src/com/amazon/ion/benchmark/IonSchemaUtilities.java
+++ b/src/com/amazon/ion/benchmark/IonSchemaUtilities.java
@@ -56,7 +56,8 @@ public class IonSchemaUtilities {
             ISS.newSchema(schema.iterator());
         } catch (InvalidSchemaException e) {
             System.out.println(e.getMessage());
-        } throw new Exception("The provided ion schema file is not valid");
+            throw new Exception("The provided ion schema file is not valid");
+        }
     }
 
     /**

--- a/src/com/amazon/ion/benchmark/ReadGeneralConstraints.java
+++ b/src/com/amazon/ion/benchmark/ReadGeneralConstraints.java
@@ -46,13 +46,14 @@ public class ReadGeneralConstraints {
                             WriteRandomIonValues.writeRandomStructValues(size, format, outputFile, constraintStruct);
                             break;
                         case TIMESTAMP:
-                            WriteRandomIonValues.writeRandomTimestamps(size, type, outputFile, null, format);
+                            WriteRandomIonValues.writeRandomTimestampsFromSchema(size, type, outputFile, format, constraintStruct);
                             break;
                         case STRING:
                             int codePointBoundary = IonSchemaUtilities.parseConstraints(constraintStruct, IonSchemaUtilities.KEYWORD_CODE_POINT_LENGTH);
                             WriteRandomIonValues.writeRandomStrings(size, type, outputFile, DEFAULT_RANGE, format, codePointBoundary);
                             break;
                         case DECIMAL:
+                            WriteRandomIonValues.writeRandomDecimalsFromSchema(size, type, outputFile, format, constraintStruct);
                             break;
                         case INT:
                             WriteRandomIonValues.writeRandomInts(size, type, format, outputFile);
@@ -62,7 +63,7 @@ public class ReadGeneralConstraints {
                             break;
                         case BLOB:
                         case CLOB:
-                            WriteRandomIonValues.writeRandomLobs(size, type, format, outputFile);
+                            WriteRandomIonValues.writeRandomLobs(size, type, format, outputFile, constraintStruct);
                             break;
                         case SYMBOL:
                             WriteRandomIonValues.writeRandomSymbolValues(size, format, outputFile);

--- a/tst/com/amazon/ion/benchmark/DataGeneratorTest.java
+++ b/tst/com/amazon/ion/benchmark/DataGeneratorTest.java
@@ -52,6 +52,10 @@ public class DataGeneratorTest {
     private final static String INPUT_ION_STRUCT_FILE_PATH = "./tst/com/amazon/ion/benchmark/testStruct.isl";
     private final static String INPUT_ION_LIST_FILE_PATH = "./tst/com/amazon/ion/benchmark/testList.isl";
     private final static String INPUT_NESTED_ION_STRUCT_PATH = "./tst/com/amazon/ion/benchmark/testNestedStruct.isl";
+    private final static String INPUT_ION_DECIMAL_FILE_PATH = "./tst/com/amazon/ion/benchmark/testDecimal.isl";
+    private final static String INPUT_ION_TIMESTAMP_FILE_PATH = "./tst/com/amazon/ion/benchmark/testTimestamp.isl";
+    private final static String INPUT_ION_CLOB_FILE_PATH = "./tst/com/amazon/ion/benchmark/testClob.isl";
+    private final static String INPUT_ION_BLOB_FILE_PATH = "./tst/com/amazon/ion/benchmark/testBlob.isl";
     private final static String SCORE_DIFFERENCE = "scoreDifference";
     private final static String COMPARISON_REPORT_WITHOUT_REGRESSION = "./tst/com/amazon/ion/benchmark/testComparisonReportWithoutRegression.ion";
     private final static String COMPARISON_REPORT = "./tst/com/amazon/ion/benchmark/testComparisonReport.ion";
@@ -102,7 +106,7 @@ public class DataGeneratorTest {
                     break;
                 }
             }
-            // Construct new schema amd get the type of the Ion Schema.
+            // Construct new schema and get the type of the Ion Schema.
             Schema newSchema = ISS.newSchema(schema.iterator());
             Type type = newSchema.getType(ionSchemaName);
             while (reader.next() != null) {
@@ -286,6 +290,42 @@ public class DataGeneratorTest {
     @Test
     public void testViolationOfNestedIonStruct() throws Exception {
         DataGeneratorTest.violationDetect(INPUT_NESTED_ION_STRUCT_PATH);
+    }
+
+    /**
+     * Test if there's violation when generating Ion Timestamp based on Ion Schema.
+     * @throws Exception if error occurs during the violation detecting process.
+     */
+    @Test
+    public void testViolationOfTimestamp() throws Exception {
+        DataGeneratorTest.violationDetect(INPUT_ION_TIMESTAMP_FILE_PATH);
+    }
+
+    /**
+     * Test if there's violation when generating decimals based on Ion Schema.
+     * @throws Exception if error occurs during the violation detecting process.
+     */
+    @Test
+    public void testViolationOfIonDecimal() throws Exception {
+        DataGeneratorTest.violationDetect(INPUT_ION_DECIMAL_FILE_PATH);
+    }
+
+    /**
+     * Test if there's violation when generating clobs based on Ion Schema.
+     * @throws Exception if error occurs during the violation detecting process.
+     */
+    @Test
+    public void testViolationOfIonClob() throws Exception {
+        DataGeneratorTest.violationDetect(INPUT_ION_CLOB_FILE_PATH);
+    }
+
+    /**
+     * Test if there's violation when generating blobs based on Ion Schema.
+     * @throws Exception if error occurs during the violation detecting process.
+     */
+    @Test
+    public void testViolationOfIonBlob() throws Exception {
+        DataGeneratorTest.violationDetect(INPUT_ION_BLOB_FILE_PATH);
     }
 
     /**

--- a/tst/com/amazon/ion/benchmark/testBlob.isl
+++ b/tst/com/amazon/ion/benchmark/testBlob.isl
@@ -1,0 +1,9 @@
+schema_header::{
+}
+type::{
+    name: Blob,
+    type: blob,
+    byte_length: range::[10, 100],
+}
+schema_footer::{
+}

--- a/tst/com/amazon/ion/benchmark/testClob.isl
+++ b/tst/com/amazon/ion/benchmark/testClob.isl
@@ -1,0 +1,9 @@
+schema_header::{
+}
+type::{
+    name: Clob,
+    type: clob,
+    byte_length: range::[2, 100],
+}
+schema_footer::{
+}

--- a/tst/com/amazon/ion/benchmark/testDecimal.isl
+++ b/tst/com/amazon/ion/benchmark/testDecimal.isl
@@ -1,0 +1,10 @@
+schema_header::{
+}
+type::{
+    name: Decimal,
+    type: decimal,
+    precision: range::[5, 9],
+    scale: 2,
+}
+schema_footer::{
+}

--- a/tst/com/amazon/ion/benchmark/testTimestamp.isl
+++ b/tst/com/amazon/ion/benchmark/testTimestamp.isl
@@ -1,0 +1,9 @@
+schema_header::{
+}
+type::{
+    name: Timestamp,
+    type: timestamp,
+    timestamp_precision: range::[year, day],
+}
+schema_footer::{
+}


### PR DESCRIPTION
**Description of changes:**
In this pull request, more features were added to support Ion Data Generator to process more constraints provided by Ion Schema. The supported Ion Schema constraints in this PR includes:

- Timestamp:
```
   timestamp_precision:<RANGE<TIMESTAMP_PRECISION_VALUE>>
```
- Decimal:
```
   precision: <INT>
   precision: <RANGE<INT>>
   scale: <INT>
   scale: <RANGE<INT>>
 ```
- Clob/Blob:
 ```
   byte_length: <INT>
   byte_length: <RANGE<INT>>
 ```

1. IonSchedmaUtilities.java

- Adds logic to process timestamp_precision:<RANGE<TIMESTAMP_PRECISION_VALUE>> to the method `IonSchemaUtilities.parseConstraints`.
- Adds method `IonSchedmaUtilities.checkValidationOfSchema` to check the validation of input ion schema file.

2. WriteRandomIonValues.java

- Adds method `WriteRandomIonValues.writeRandomDecimalsFromSchema` which is able to process the constraints of decimal.
- Adds method `WriteRandomIonValues.writeRandomTimestampsFromSchema` which is able to process the constraints of timestamp.
- Adds parameter constraintStruct to method `WriteRandomIonValues.writeRandomLobs` to allow the method to process the constraints of clob.
- Add method `WriteRandomIonValues.constructDecimalFromSchema` which is able to construct the decimal conforming with the constraints in Ion Schema.

**Test:**
- Adds two ISL file (testTimestamp.isl, testDecimal.isl, testClob.isl, testBlob.isl) as inputs to test the Ion Data generator.
- Adds methods to test whether there is violation when generating timestamps , clobs, blobs, and decimals.

**Commits history reference:**
https://github.com/linlin-s/ion-java-benchmark-cli/pull/8

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.