### PR TITLE
Adds features to process constraint 'element' and generate IonSexp.

### DIFF
--- a/src/com/amazon/ion/benchmark/DataConstructor.java
+++ b/src/com/amazon/ion/benchmark/DataConstructor.java
@@ -17,6 +17,8 @@ package com.amazon.ion.benchmark;
 
 import com.amazon.ion.IonList;
 import com.amazon.ion.IonReader;
+import com.amazon.ion.IonSequence;
+import com.amazon.ion.IonSexp;
 import com.amazon.ion.IonStruct;
 import com.amazon.ion.IonSystem;
 import com.amazon.ion.IonTimestamp;
@@ -26,6 +28,7 @@ import com.amazon.ion.IonWriter;
 import com.amazon.ion.Timestamp;
 import com.amazon.ion.benchmark.schema.ReparsedType;
 import com.amazon.ion.benchmark.schema.constraints.Contains;
+import com.amazon.ion.benchmark.schema.constraints.Element;
 import com.amazon.ion.benchmark.schema.constraints.Fields;
 import com.amazon.ion.benchmark.schema.constraints.OrderedElements;
 import com.amazon.ion.benchmark.schema.constraints.QuantifiableConstraints;
@@ -71,10 +74,12 @@ class DataConstructor {
     final static private int DEFAULT_PRECISION = 20;
     final static private int DEFAULT_SCALE_LOWER_BOUND = -20;
     final static private int DEFAULT_SCALE_UPPER_BOUND = 20;
+    final static private int DEFAULT_CONTAINER_LENGTH = 20;
     final static private Set<String> VALID_STRING_SYMBOL_CONSTRAINTS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList("regex", "codepoint_length")));
     final static private Set<String> VALID_DECIMAL_CONSTRAINTS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList("precision", "scale")));
     final static private Set<String> VALID_TIMESTAMP_CONSTRAINTS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList("timestamp_offset", "timestamp_precision")));
-    final static private Set<String> VALID_LIST_CONSTRAINTS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList("contains", "ordered_elements")));
+    final static private Set<String> VALID_SEQUENCE_CONSTRAINTS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList("contains", "element", "ordered_elements")));
+    final static private Set<String> VALID_STRUCT_CONSTRAINTS = Collections.unmodifiableSet(new HashSet<>(Arrays.asList("element", "fields")));
     // Create a range which contains the default lower bound and upper bound values.
     final static private Range DEFAULT_TIMESTAMP_IN_MILLIS_DECIMAL_RANGE = new Range(SYSTEM.newList( SYSTEM.newDecimal(62135769600000L), SYSTEM.newDecimal(253402300800000L)));
 
@@ -231,7 +236,11 @@ class DataConstructor {
                 case STRUCT:
                     return constructIonStruct(constraintMapClone);
                 case LIST:
-                    return constructIonList(constraintMapClone);
+                    IonList listContainer = SYSTEM.newEmptyList();
+                    return constructSequenceTypeData(constraintMapClone, listContainer);
+                case SEXP:
+                    IonSexp sexpContainer = SYSTEM.newEmptySexp();
+                    return constructSequenceTypeData(constraintMapClone, sexpContainer);
                 default:
                     throw new IllegalStateException(type + " is not supported.");
             }
@@ -246,60 +255,76 @@ class DataConstructor {
      */
     private static IonStruct constructIonStruct(Map<String, ReparsedConstraint> constraintMapClone) {
         Fields fields = (Fields)constraintMapClone.remove("fields");
+        Element element = (Element)constraintMapClone.remove("element");
+        QuantifiableConstraints container_length = (QuantifiableConstraints)constraintMapClone.remove("container_length");
         Random random = new Random();
         IonStruct constructedIonStruct = SYSTEM.newEmptyStruct();
-        Map<String, ReparsedType> fieldMap = fields.getFieldMap();
         // Check if there is unhandled constraint provided.
         if (!constraintMapClone.isEmpty()) {
             throw new IllegalStateException ("Found unhandled constraints : " + constraintMapClone.values());
         }
-        // Writing field value to IonStruct based on the relevant constraint.
-        for (Map.Entry<String, ReparsedType> entry : fieldMap.entrySet()) {
-            // Get the type definition for each field.
-            ReparsedType fieldTypeDefinition = entry.getValue();
-            // 'occurs' included in the field constraint determines the occurrences of the specified field.
-            int occurs = ReparsedType.getOccurs(fieldTypeDefinition.getConstraintStruct());
-            int occurTime = occurs == -1 ? random.nextInt(2) : occurs;
-            int i = 0;
-            while (i < occurTime) {
-                constructedIonStruct.add(entry.getKey(), constructIonData(fieldTypeDefinition));
-                i++;
+        if (element != null && fields != null) {
+            throw new IllegalStateException("Can only handle one of : " + VALID_STRUCT_CONSTRAINTS);
+        } else if (element != null) {
+            int length = container_length == null ? DEFAULT_CONTAINER_LENGTH : container_length.getRange().getRandomQuantifiableValueFromRange().intValue();
+            for (int i = 0; i < length; i++) {
+                constructedIonStruct.add(constructStringFromCodepointLength(random.nextInt(20)), constructIonData(element.getElement()));
+            }
+        } else {
+            Map<String, ReparsedType> fieldMap = fields.getFieldMap();
+            // Writing field value to IonStruct based on the relevant constraint.
+            for (Map.Entry<String, ReparsedType> entry : fieldMap.entrySet()) {
+                // Get the type definition for each field.
+                ReparsedType fieldTypeDefinition = entry.getValue();
+                // 'occurs' included in the field constraint determines the occurrences of the specified field.
+                int occurs = ReparsedType.getOccurs(fieldTypeDefinition.getConstraintStruct());
+                int occurTime = occurs == -1 ? random.nextInt(2) : occurs;
+                for (int i = 0; i < occurTime; i++) {
+                    constructedIonStruct.add(entry.getKey(), constructIonData(fieldTypeDefinition));
+                }
             }
         }
         return constructedIonStruct;
     }
 
     /**
-     * Constructing IonList which is aligned with the constraints provided in the constraintMap.
+     * Constructing IonSequence value which is aligned with the constraints provided in the constraintMap.
      * @param constraintMapClone collects the constraints from ISL file, the key represents the name of constraints,
      * and the value is constraint value in ReparsedConstraint format.
-     * @return the constructed IonList value.
+     * @param container represents one of the element from set (IonList | IonSexp).
+     * @return the constructed IonSequence value.
      */
-    private static IonList constructIonList(Map<String, ReparsedConstraint> constraintMapClone) {
+    private static IonValue constructSequenceTypeData(Map<String, ReparsedConstraint> constraintMapClone, IonSequence container) {
         Contains contains = (Contains)constraintMapClone.remove("contains");
         OrderedElements elementsConstraints = (OrderedElements)constraintMapClone.remove("ordered_elements");
+        Element element = (Element)constraintMapClone.remove("element");
+        QuantifiableConstraints container_length = (QuantifiableConstraints)constraintMapClone.remove("container_length");
         if (!constraintMapClone.isEmpty()) {
             throw new IllegalStateException ("Found unhandled constraints : " + constraintMapClone.values());
         }
-        if (contains != null && elementsConstraints != null) {
-            throw new IllegalStateException("Can only handle one of : " + VALID_LIST_CONSTRAINTS);
+        // TODO: Consider to construct composable data-generator for each constraint to avoid the multiple conditions in one 'if/else' statement.
+        if ((contains != null && elementsConstraints != null) || (elementsConstraints != null && element != null) || (contains != null && element != null)) {
+            throw new IllegalStateException("Can only handle one of : " + VALID_SEQUENCE_CONSTRAINTS);
+        } else if (element != null) {
+            int length = container_length == null ? DEFAULT_CONTAINER_LENGTH : container_length.getRange().getRandomQuantifiableValueFromRange().intValue();
+            for (int i = 0 ; i < length; i++) {
+                container.add(constructIonData(element.getElement()));
+            }
+            return container;
         } else if (contains != null) {
             // TODO: The return IonList should also include other random values except the values provided by 'contains'.
             return contains.getExpectedContainedValues();
         } else {
             ArrayList<ReparsedType> orderedElementsConstraints = elementsConstraints.getOrderedElementsConstraints();
-            IonList resultList = SYSTEM.newEmptyList();
             for (ReparsedType constraint : orderedElementsConstraints) {
                 // 'occurs' included in the constraint of 'ordered_element' indicates the occurrences of the specified element.
                 int occurs = ReparsedType.getOccurs(constraint.getConstraintStruct());
                 int occurTime = occurs == -1 ? 1 : occurs;
-                int i = 0;
-                while (i < occurTime) {
-                    resultList.add(constructIonData(constraint));
-                    i++;
+                for (int i = 0; i < occurTime; i++) {
+                    container.add(constructIonData(constraint));
                 }
             }
-            return resultList;
+            return container;
         }
     }
 
@@ -324,7 +349,6 @@ class DataConstructor {
         Random random = new Random();
         Regex regex = (Regex) constraintMapClone.remove("regex");
         QuantifiableConstraints codepoint_length = (QuantifiableConstraints) constraintMapClone.remove("codepoint_length");
-
         if (!constraintMapClone.isEmpty()) {
             throw new IllegalStateException ("Found unhandled constraints : " + constraintMapClone.values());
         }

--- a/src/com/amazon/ion/benchmark/DataConstructor.java
+++ b/src/com/amazon/ion/benchmark/DataConstructor.java
@@ -294,7 +294,7 @@ class DataConstructor {
      * @param container represents one of the element from set (IonList | IonSexp).
      * @return the constructed IonSequence value.
      */
-    private static IonValue constructSequenceTypeData(Map<String, ReparsedConstraint> constraintMapClone, IonSequence container) {
+    private static IonSequence constructSequenceTypeData(Map<String, ReparsedConstraint> constraintMapClone, IonSequence container) {
         Contains contains = (Contains)constraintMapClone.remove("contains");
         OrderedElements elementsConstraints = (OrderedElements)constraintMapClone.remove("ordered_elements");
         Element element = (Element)constraintMapClone.remove("element");

--- a/src/com/amazon/ion/benchmark/schema/ReparsedType.java
+++ b/src/com/amazon/ion/benchmark/schema/ReparsedType.java
@@ -4,6 +4,7 @@ import com.amazon.ion.IonStruct;
 import com.amazon.ion.IonType;
 import com.amazon.ion.IonValue;
 import com.amazon.ion.benchmark.schema.constraints.Contains;
+import com.amazon.ion.benchmark.schema.constraints.Element;
 import com.amazon.ion.benchmark.schema.constraints.Fields;
 import com.amazon.ion.benchmark.schema.constraints.OrderedElements;
 import com.amazon.ion.benchmark.schema.constraints.QuantifiableConstraints;
@@ -29,6 +30,7 @@ public class ReparsedType {
     private static final String KEYWORD_VALID_VALUES = "valid_values";
     private static final String KEYWORD_NAME = "name";
     private static final String KEYWORD_FIELDS = "fields";
+    private static final String KEYWORD_ELEMENT = "element";
     private static final String KEYWORD_CONTAINS = "contains";
     private static final String KEYWORD_ORDERED_ELEMENTS = "ordered_elements";
     // Using map to avoid processing the multiple repeat constraints situation.
@@ -138,6 +140,8 @@ public class ReparsedType {
                 return OrderedElements.of(field);
             case KEYWORD_CONTAINS:
                 return Contains.of(field);
+            case KEYWORD_ELEMENT:
+                return Element.of(field);
             default:
                 // For now, Ion Data Generator doesn't support processing 'open' content.
                 // If the constraint 'content' included in the ISL , the data generator will throw an exception.

--- a/src/com/amazon/ion/benchmark/schema/constraints/Element.java
+++ b/src/com/amazon/ion/benchmark/schema/constraints/Element.java
@@ -1,0 +1,34 @@
+package com.amazon.ion.benchmark.schema.constraints;
+
+import com.amazon.ion.IonValue;
+import com.amazon.ion.benchmark.IonSchemaUtilities;
+import com.amazon.ion.benchmark.schema.ReparsedType;
+
+public class Element implements ReparsedConstraint {
+    private ReparsedType element;
+
+    /**
+     * Initializing the newly created Element object.
+     * @param field represents the value of constraint 'element'.
+     */
+    private Element (IonValue field) {
+        this.element = IonSchemaUtilities.parseTypeReference(field);
+    }
+
+    /**
+     * Parsing the value of constraint 'element' into Element.
+     * @param field represents the value of constraint 'element'.
+     * @return the parsed object Element.
+     */
+    public static Element of (IonValue field) {
+        return new Element(field);
+    }
+
+    /**
+     * Helping access the private attribute 'element'.
+     * @return the attribute 'element'.
+     */
+    public ReparsedType getElement() {
+        return this.element;
+    }
+}

--- a/tst/com/amazon/ion/benchmark/DataGeneratorTest.java
+++ b/tst/com/amazon/ion/benchmark/DataGeneratorTest.java
@@ -47,6 +47,8 @@ public class DataGeneratorTest {
     private final static String INPUT_NESTED_ION_STRUCT_PATH = "./tst/com/amazon/ion/benchmark/testNestedStruct.isl";
     private final static String INPUT_ION_DECIMAL_FILE_PATH = "./tst/com/amazon/ion/benchmark/testDecimal.isl";
     private final static String INPUT_ION_TIMESTAMP_FILE_PATH = "./tst/com/amazon/ion/benchmark/testTimestamp.isl";
+    private final static String INPUT_ION_STRUCT_SCHEMA_CONTAINS_ELEMENT_FILE_PATH = "./tst/com/amazon/ion/benchmark/testSchemaContainsElement.isl";
+    private final static String INPUT_ION_SEXP_FILE_PATH = "./tst/com/amazon/ion/benchmark/testSexp.isl";
     private final static String INPUT_ION_CLOB_FILE_PATH = "./tst/com/amazon/ion/benchmark/testClob.isl";
     private final static String INPUT_ION_BLOB_FILE_PATH = "./tst/com/amazon/ion/benchmark/testBlob.isl";
     private final static String INPUT_ION_FLOAT_FILE_PATH = "./tst/com/amazon/ion/benchmark/testFloat.isl";
@@ -182,12 +184,30 @@ public class DataGeneratorTest {
     }
 
     /**
+     * Test if there's violation when generating Ion Sexp based on Ion Schema.
+     * @throws Exception if error occurs during the violation detecting process.
+     */
+    @Test
+    public void testViolationOfSexp() throws Exception {
+        DataGeneratorTest.violationDetect(INPUT_ION_SEXP_FILE_PATH);
+    }
+
+    /**
      * Test if there's violation when generating nested Ion Struct based on Ion Schema.
      * @throws Exception if error occurs during the violation detecting process.
      */
     @Test
     public void testViolationOfNestedIonList() throws Exception {
         DataGeneratorTest.violationDetect(INPUT_NESTED_ION_LIST_PATH);
+    }
+
+    /**
+     * Test if there's violation when generating IonStruct based on Ion Schema contains constraint 'element'.
+     * @throws Exception if error occurs during the violation detecting process.
+     */
+    @Test
+    public void testViolationOfIonStructWithElement() throws Exception {
+        DataGeneratorTest.violationDetect(INPUT_ION_STRUCT_SCHEMA_CONTAINS_ELEMENT_FILE_PATH);
     }
 
     /**

--- a/tst/com/amazon/ion/benchmark/DataGeneratorTest.java
+++ b/tst/com/amazon/ion/benchmark/DataGeneratorTest.java
@@ -49,6 +49,7 @@ public class DataGeneratorTest {
     private final static String INPUT_ION_TIMESTAMP_FILE_PATH = "./tst/com/amazon/ion/benchmark/testTimestamp.isl";
     private final static String INPUT_ION_STRUCT_SCHEMA_CONTAINS_ELEMENT_FILE_PATH = "./tst/com/amazon/ion/benchmark/testSchemaContainsElement.isl";
     private final static String INPUT_ION_SEXP_FILE_PATH = "./tst/com/amazon/ion/benchmark/testSexp.isl";
+    private final static String INPUT_TEST_ELEMENT_SCHEMA = "./tst/com/amazon/ion/benchmark/testElement.isl";
     private final static String INPUT_ION_CLOB_FILE_PATH = "./tst/com/amazon/ion/benchmark/testClob.isl";
     private final static String INPUT_ION_BLOB_FILE_PATH = "./tst/com/amazon/ion/benchmark/testBlob.isl";
     private final static String INPUT_ION_FLOAT_FILE_PATH = "./tst/com/amazon/ion/benchmark/testFloat.isl";
@@ -199,6 +200,15 @@ public class DataGeneratorTest {
     @Test
     public void testViolationOfNestedIonList() throws Exception {
         DataGeneratorTest.violationDetect(INPUT_NESTED_ION_LIST_PATH);
+    }
+
+    /**
+     * Test if there's violation when generating IonList based on ISL that specifies constraint 'element' without specifying 'container_length'.
+     * @throws Exception if error occurs during the violation detecting process.
+     */
+    @Test
+    public void testViolationOfConstraintElement() throws Exception {
+        DataGeneratorTest.violationDetect(INPUT_TEST_ELEMENT_SCHEMA);
     }
 
     /**

--- a/tst/com/amazon/ion/benchmark/testElement.isl
+++ b/tst/com/amazon/ion/benchmark/testElement.isl
@@ -1,0 +1,5 @@
+ type::{
+      name: List,
+      type: list,
+      element: { type: timestamp, timestamp_precision: range::[year, day] },
+ }

--- a/tst/com/amazon/ion/benchmark/testSchemaContainsElement.isl
+++ b/tst/com/amazon/ion/benchmark/testSchemaContainsElement.isl
@@ -1,0 +1,6 @@
+type::{
+    name: StructWithElement,
+    type: struct,
+    element: { type: timestamp, timestamp_precision: range::[year, day]},
+    container_length: 4,
+}

--- a/tst/com/amazon/ion/benchmark/testSexp.isl
+++ b/tst/com/amazon/ion/benchmark/testSexp.isl
@@ -1,0 +1,6 @@
+ type::{
+      name: Sexp,
+      type: sexp,
+      element: { type: string, regex: "^B[0-9]{9}$" },
+      container_length: range :: [7, 10],
+ }


### PR DESCRIPTION
*Issue #, if available:*

N/A

***Description of changes:***
This PR added features to generate `IonSexp` and also contains the feature to process constraint `element`. We test the validation of the generated data by providing test ISL files which contain the relevant constraints.

**DataConstructor.java:**

- constructSequenceTypeData:
Added the logic of generating `IonSexp`. `IonSexp` generation process shared the same logic with `IonList` generation.
In this method, the first step is to check if there are potentially conflict constraints in the provided ISL file and then generating data based on the provided constraints. The newly added logic is processing constraint `element`. The way of processing `element` is to parse the value of `element` into `ReparsedType` then pass the re-parsed value to method `constructIonData` to generate data recursively. Constraint `element` can also work with constraint `container_length` (if it is contained in the ISL file) together, and constraint `container_length` helps decide the length of generated container type data.
- constructIonStruct:
In this method we also added logic to process the constraint `element`. If `element` provided in `IonStruct` ISL file, then the field values in the generated `IonStruct` would be aligned with constraint `element`, and the filed name would be a random string with default `codepoint_length` range `[0, 20)`.

**ReparsedType.java:**

- Added case to parse the constraint `element`.

**Element.java:**

- This is the newly added class which is used for parsing constraint `element`.

**Test:**

- Added test case of generating `IonStruct` which is conformed with the ISL contains constraint `element`.
- Added test case to check whether there is violation while generating `IonSexp`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
