### PR TITLE
Adds feature to process the constraint 'annotations'.

### DIFF
--- a/src/com/amazon/ion/benchmark/schema/ReparsedType.java
+++ b/src/com/amazon/ion/benchmark/schema/ReparsedType.java
@@ -3,6 +3,7 @@ package com.amazon.ion.benchmark.schema;
 import com.amazon.ion.IonStruct;
 import com.amazon.ion.IonType;
 import com.amazon.ion.IonValue;
+import com.amazon.ion.benchmark.schema.constraints.Annotations;
 import com.amazon.ion.benchmark.schema.constraints.Contains;
 import com.amazon.ion.benchmark.schema.constraints.Element;
 import com.amazon.ion.benchmark.schema.constraints.Fields;
@@ -13,6 +14,7 @@ import com.amazon.ion.benchmark.schema.constraints.ReparsedConstraint;
 import com.amazon.ion.benchmark.schema.constraints.TimestampPrecision;
 import com.amazon.ion.benchmark.schema.constraints.ValidValues;
 
+import java.lang.reflect.AnnotatedArrayType;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -33,6 +35,7 @@ public class ReparsedType {
     private static final String KEYWORD_ELEMENT = "element";
     private static final String KEYWORD_CONTAINS = "contains";
     private static final String KEYWORD_ORDERED_ELEMENTS = "ordered_elements";
+    private static final String KEYWORD_ANNOTATIONS = "annotations";
     // Using map to avoid processing the multiple repeat constraints situation.
     private final Map<String, ReparsedConstraint> constraintMap;
     private final IonStruct constraintStruct;
@@ -142,6 +145,8 @@ public class ReparsedType {
                 return Contains.of(field);
             case KEYWORD_ELEMENT:
                 return Element.of(field);
+            case KEYWORD_ANNOTATIONS:
+                return Annotations.of(field);
             default:
                 // For now, Ion Data Generator doesn't support processing 'open' content.
                 // If the constraint 'content' included in the ISL , the data generator will throw an exception.

--- a/src/com/amazon/ion/benchmark/schema/constraints/Annotations.java
+++ b/src/com/amazon/ion/benchmark/schema/constraints/Annotations.java
@@ -1,0 +1,74 @@
+package com.amazon.ion.benchmark.schema.constraints;
+
+import com.amazon.ion.IonList;
+import com.amazon.ion.IonValue;
+
+import java.util.Arrays;
+import java.util.Random;
+
+/**
+ * This class aims to process the constraint 'annotations'. After parsing the constraint value to Annotations object, we
+ * are able to get the processed annotations in an IonList format.
+ */
+public class Annotations implements ReparsedConstraint {
+    private IonList annotations;
+
+    /**
+     * Initializing the newly created Annotations object.
+     * @param field represents the value of constraint 'annotations'.
+     */
+    private Annotations(IonValue field) {
+        this.annotations = parseAnnotations(field);
+    }
+
+    /**
+     * Helping access the private attribute 'annotations'.
+     * @return the attribute 'annotations'.
+     */
+    public IonList getAnnotations() {
+        return this.annotations;
+    }
+
+    /**
+     * Process the annotation of the constraint 'annotations'. By default, individual annotations
+     * are optional and this default may be overridden by annotating the annotations list with 'required'.
+     * If annotations must be applied to value in specified order, the list may be annotated with 'ordered'.
+     * This method will process these annotations and return the value aligned with these specifications.
+     * @param field represents the value of constraint 'annotations'.
+     * @return the list of annotations that are used for annotating IonValue.
+     */
+    private IonList parseAnnotations(IonValue field) {
+        String[] annotationsSpecificationList = field.getTypeAnnotations();
+        // If the constraint 'annotation' is not annotated or annotated with "optional",
+        if (annotationsSpecificationList.length == 0 || Arrays.asList(annotationsSpecificationList).contains("optional")) {
+            return randomlyReturnAnnotations(field);
+        } else {
+            return (IonList)field;
+        }
+    }
+
+    /**
+     * Process the constraint 'annotations' without annotation or contains 'optional' annotation.
+     * @param field represents the value of constraint 'annotations'.
+     * @return a null value or a list of annotations randomly.
+     */
+    private IonList randomlyReturnAnnotations(IonValue field) {
+        Random random = new Random();
+        int value = random.nextInt(2);
+        switch (value) {
+            case 1:
+                return (IonList)field;
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * Parsing the value of constraint 'annotations' into Annotations.
+     * @param field represents the value of constraint 'annotations'.
+     * @return the parsed object Annotations.
+     */
+    public static Annotations of(IonValue field) {
+        return new Annotations(field);
+    }
+}

--- a/src/com/amazon/ion/benchmark/schema/constraints/Annotations.java
+++ b/src/com/amazon/ion/benchmark/schema/constraints/Annotations.java
@@ -39,8 +39,13 @@ public class Annotations implements ReparsedConstraint {
      */
     private IonList parseAnnotations(IonValue field) {
         String[] annotationsSpecificationList = field.getTypeAnnotations();
-        // If the constraint 'annotation' is not annotated or annotated with "optional",
-        if (annotationsSpecificationList.length == 0 || Arrays.asList(annotationsSpecificationList).contains("optional")) {
+        // We do not consider the features of 'annotations' in the element level.
+        // i.e. 'annotations' has annotation for each listed annotation in the constraint value.(required | optional)
+        // For the list level annotation, we only consider the default condition (when the constraint 'annotations' is not annotated).
+        // For the rest of the list level features (required | closed | ordered), we categorise them as one condition and then return the value of constraint annotations directly.
+
+        // If the constraint 'annotations' is not annotated, the list of annotations will be considered as optional.
+        if (annotationsSpecificationList.length == 0) {
             return randomlyReturnAnnotations(field);
         } else {
             return (IonList)field;

--- a/tst/com/amazon/ion/benchmark/DataGeneratorTest.java
+++ b/tst/com/amazon/ion/benchmark/DataGeneratorTest.java
@@ -55,6 +55,7 @@ public class DataGeneratorTest {
     private final static String INPUT_ION_FLOAT_FILE_PATH = "./tst/com/amazon/ion/benchmark/testFloat.isl";
     private final static String INPUT_ION_FLOAT_VALID_VALUE_FILE_PATH = "./tst/com/amazon/ion/benchmark/testFloatValidValue.isl";
     private final static String INPUT_ION_SYMBOL_FILE_PATH = "./tst/com/amazon/ion/benchmark/testSymbol.isl";
+    private final static String INPUT_SCHEMA_CONTAINS_ANNOTATIONS = "./tst/com/amazon/ion/benchmark/testAnnotations.isl";
     private final static String INPUT_ION_STRING_FILE_PATH = "./tst/com/amazon/ion/benchmark/testString.isl";
     private final static String INPUT_ION_INT_FILE_PATH = "./tst/com/amazon/ion/benchmark/testInt.isl";
     private final static String SCORE_DIFFERENCE = "scoreDifference";
@@ -182,6 +183,15 @@ public class DataGeneratorTest {
     @Test
     public void testViolationOfNestedIonStruct() throws Exception {
         DataGeneratorTest.violationDetect(INPUT_NESTED_ION_STRUCT_PATH);
+    }
+
+    /**
+     * Test if there's violation when generating IonValue from ISL which contains constraint 'annotations'.
+     * @throws Exception if error occurs during the violation detecting process.
+     */
+    @Test
+    public void testAnnotations() throws Exception {
+        DataGeneratorTest.violationDetect(INPUT_SCHEMA_CONTAINS_ANNOTATIONS);
     }
 
     /**

--- a/tst/com/amazon/ion/benchmark/testAnnotations.isl
+++ b/tst/com/amazon/ion/benchmark/testAnnotations.isl
@@ -1,0 +1,18 @@
+type::{
+    name: TestAnnotations,
+    type: struct,
+    annotations:optional::[struct, nestedStruct],
+    fields: {
+      firstName: { type: string, occurs: required, annotations: required::[test] },
+      lastName: { type: string, occurs: optional, annotations: ordered::[test, ordered, annotations]  },
+      last_updated: { type: timestamp, timestamp_precision: year, occurs: required},
+      addresses: {
+            type:list,
+            ordered_elements: [
+                                   {type:string, occurs: optional},
+                                   int,
+                                   { type: int, occurs: range::[0, 10] },
+                                 ],
+      }
+    },
+}

--- a/tst/com/amazon/ion/benchmark/testAnnotations.isl
+++ b/tst/com/amazon/ion/benchmark/testAnnotations.isl
@@ -1,7 +1,7 @@
 type::{
     name: TestAnnotations,
     type: struct,
-    annotations:optional::[struct, nestedStruct],
+    annotations:[struct, nestedStruct],
     fields: {
       firstName: { type: string, occurs: required, annotations: required::[test] },
       lastName: { type: string, occurs: optional, annotations: ordered::[test, ordered, annotations]  },


### PR DESCRIPTION
*Issue #, if available:*

***Description of changes:***
This PR adds class `Annotations` to process the constraint `annotations`. After parsing the constraint value to `Annotations`, we are able to get a list of annotations or `null` based on the annotation `required | optional | ordered `of the constraint.

**DataConstructor.java:**

- In the method `constructIonData`, instead of returning the value directly for each type case, overwriting the result variable which stores the constructed Ion data. And then check whether the constraint `annotations` is provided in the same level of data structure. If the constraint `annotations` provided, the `annotations` value will be added to the constructed data and be returned.

**ReparsedType.java**

- Adds the case  `ANNOTATIONS` to the method of parsing constraint value to `ReparsedConstraint`.

**Annotations:**

- This class is used for parsing the value of constraint `annotations`. This class provides an attribute that allows users to get the processed `annotations` value in an IonList format.

**Test:**
Adds a test case that cover the constraint `annotations` .


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
