### PR TITLE
Adds unit test for constriant 'codepoint_length'.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>com.amazon.ion</groupId>
             <artifactId>ion-schema-kotlin</artifactId>
-            <version>1.1.0</version>
+            <version>1.3.0</version>
         </dependency>
         <dependency>
             <groupId>com.github.curious-odd-man</groupId>

--- a/tst/com/amazon/ion/benchmark/DataGeneratorTest.java
+++ b/tst/com/amazon/ion/benchmark/DataGeneratorTest.java
@@ -47,6 +47,7 @@ public class DataGeneratorTest {
     private final static String INPUT_NESTED_ION_STRUCT_PATH = "./tst/com/amazon/ion/benchmark/testNestedStruct.isl";
     private final static String INPUT_ION_DECIMAL_FILE_PATH = "./tst/com/amazon/ion/benchmark/testDecimal.isl";
     private final static String INPUT_ION_TIMESTAMP_FILE_PATH = "./tst/com/amazon/ion/benchmark/testTimestamp.isl";
+    private final static String INPUT_SCHEMA_CONTAINS_CODEPOINT_LENGTH = "./tst/com/amazon/ion/benchmark/testStringCodepointLength.isl";
     private final static String INPUT_ION_STRUCT_SCHEMA_CONTAINS_ELEMENT_FILE_PATH = "./tst/com/amazon/ion/benchmark/testSchemaContainsElement.isl";
     private final static String INPUT_ION_SEXP_FILE_PATH = "./tst/com/amazon/ion/benchmark/testSexp.isl";
     private final static String INPUT_TEST_ELEMENT_SCHEMA = "./tst/com/amazon/ion/benchmark/testElement.isl";
@@ -183,6 +184,15 @@ public class DataGeneratorTest {
     @Test
     public void testViolationOfNestedIonStruct() throws Exception {
         DataGeneratorTest.violationDetect(INPUT_NESTED_ION_STRUCT_PATH);
+    }
+
+    /**
+     * Test if there's violation when generating string based on the ISL contains constraint 'codepoint_length'.
+     * @throws Exception if error occurs during the violation detecting process.
+     */
+    @Test
+    public void testCodepointLength() throws Exception {
+        DataGeneratorTest.violationDetect(INPUT_SCHEMA_CONTAINS_CODEPOINT_LENGTH);
     }
 
     /**

--- a/tst/com/amazon/ion/benchmark/testStringCodepointLength.isl
+++ b/tst/com/amazon/ion/benchmark/testStringCodepointLength.isl
@@ -1,0 +1,5 @@
+type::{
+    name: String,
+    type: string,
+    codepoint_length: range :: [4, 10],
+}


### PR DESCRIPTION
*Issue #, if available:*

Related issue:
- [Incorrect validation with CodepointLength#getIntValue()](https://github.com/amzn/ion-schema-kotlin/issues/190)
- [ Generated string length is not aligned with the specified codepoint_length. #32 ](https://github.com/amzn/ion-java-benchmark-cli/issues/32)

*Description of changes:*
The newly released `ion-schema-kotlin-1.3.0` fixed the incorrect violation with `codepoint_length`. This violation detection is used as part of unit test of `Ion Data Generator`. This PR updates the version number of `ion-schem-kotlin` and also adds the missing unit test of constraint `codepoint_length` to the testing process.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
