### PR TITLE
Updates default constraints of data generators.

### DIFF
--- a/src/com/amazon/ion/benchmark/DataConstructor.java
+++ b/src/com/amazon/ion/benchmark/DataConstructor.java
@@ -70,9 +70,12 @@ class DataConstructor {
     // The constant defined below are used as placeholder in the method WriteRandomIonValues.writeRequestedSizeFile.
     final static private IonSystem SYSTEM = IonSystemBuilder.standard().build();
     final static private List<Integer> DEFAULT_RANGE = Arrays.asList(0, 0x10FFFF);
-    final static public Timestamp.Precision[] PRECISIONS = Timestamp.Precision.values();
     final static public IonStruct NO_CONSTRAINT_STRUCT = null;
     final static private int DEFAULT_PRECISION = 20;
+    // The ASCII_CODE_LOWERCASE_A represents the ASCII code of character "a".
+    final static private int ASCII_CODE_LOWERCASE_A = 97;
+    // The ASCII_CODE_UPPERCASE_A represents the ASCII code of character "A".
+    final static private int ASCII_CODE_UPPERCASE_A = 65;
     final static private int DEFAULT_SCALE_LOWER_BOUND = -20;
     final static private int DEFAULT_SCALE_UPPER_BOUND = 20;
     final static private int DEFAULT_CONTAINER_LENGTH = 20;
@@ -396,12 +399,12 @@ class DataConstructor {
     private static int getCodePoint() {
         int index = ThreadLocalRandom.current().nextInt(20);
         int randomIndex = ThreadLocalRandom.current().nextInt(26);
-        if (index >= 0 && index < 10) {
+        if (index < 10) {
             // Randomly generate the unicode of character from [A-Z].
-            return randomIndex + 65;
+            return randomIndex + ASCII_CODE_UPPERCASE_A;
         } else {
             // Randomly generate the unicode of character from [a-z].
-            return randomIndex + 97;
+            return randomIndex + ASCII_CODE_LOWERCASE_A;
         }
     }
 
@@ -502,7 +505,7 @@ class DataConstructor {
             // In this case, the generated integers would be more similar to the real world data.
             Random random = new Random();
             int index = random.nextInt(20);
-            if (index >= 0 && index < 16) {
+            if (index < 16) {
                 return ThreadLocalRandom.current().nextInt(1024);
             } else {
                 return ThreadLocalRandom.current().nextLong();
@@ -522,7 +525,7 @@ class DataConstructor {
         // Preset the local offset.
         Integer localOffset = localOffset(random);
         // Preset the default precision as 'Day'.
-        Timestamp.Precision precision = PRECISIONS[2];
+        Timestamp.Precision precision = Timestamp.Precision.DAY;
         TimestampPrecision timestampPrecision = (TimestampPrecision) constraintMapClone.remove("timestamp_precision");
         ValidValues validValues = (ValidValues) constraintMapClone.remove("valid_values");
         if (!constraintMapClone.isEmpty()) {

--- a/src/com/amazon/ion/benchmark/DataConstructor.java
+++ b/src/com/amazon/ion/benchmark/DataConstructor.java
@@ -390,18 +390,19 @@ class DataConstructor {
     }
 
     /**
-     * Generate unicode codepoint randomly.
+     * Generate unicode codepoint randomly which matches the character from [A-Z] and [a-z].
      * @return generated codepoint.
      */
     private static int getCodePoint() {
-        Random random = new Random();
-        int type;
-        int codePoint;
-        do {
-            codePoint = random.nextInt(DEFAULT_RANGE.get(1) - DEFAULT_RANGE.get(0) + 1) + DEFAULT_RANGE.get(0);
-            type = Character.getType(codePoint);
-        } while (type == Character.PRIVATE_USE || type == Character.SURROGATE || type == Character.UNASSIGNED);
-        return codePoint;
+        int index = ThreadLocalRandom.current().nextInt(20);
+        int randomIndex = ThreadLocalRandom.current().nextInt(26);
+        if (index >= 0 && index < 10) {
+            // Randomly generate the unicode of character from [A-Z].
+            return randomIndex + 65;
+        } else {
+            // Randomly generate the unicode of character from [a-z].
+            return randomIndex + 97;
+        }
     }
 
     /**
@@ -497,7 +498,15 @@ class DataConstructor {
             return validValues.getRange().getRandomQuantifiableValueFromRange().longValue();
         } else {
             // If there is no constraint provided, the generator will construct a random value.
-            return ThreadLocalRandom.current().nextLong();
+            // Randomly generate integers in the distribution that more than 80% of integers would be smaller than 1024.
+            // In this case, the generated integers would be more similar to the real world data.
+            Random random = new Random();
+            int index = random.nextInt(20);
+            if (index >= 0 && index < 16) {
+                return ThreadLocalRandom.current().nextInt(1024);
+            } else {
+                return ThreadLocalRandom.current().nextLong();
+            }
         }
     }
 
@@ -512,8 +521,8 @@ class DataConstructor {
         Range range = DEFAULT_TIMESTAMP_IN_MILLIS_DECIMAL_RANGE;
         // Preset the local offset.
         Integer localOffset = localOffset(random);
-        // Preset the default precision.
-        Timestamp.Precision precision = PRECISIONS[random.nextInt(PRECISIONS.length)];
+        // Preset the default precision as 'Day'.
+        Timestamp.Precision precision = PRECISIONS[2];
         TimestampPrecision timestampPrecision = (TimestampPrecision) constraintMapClone.remove("timestamp_precision");
         ValidValues validValues = (ValidValues) constraintMapClone.remove("valid_values");
         if (!constraintMapClone.isEmpty()) {

--- a/tst/com/amazon/ion/benchmark/DataGeneratorTest.java
+++ b/tst/com/amazon/ion/benchmark/DataGeneratorTest.java
@@ -50,6 +50,7 @@ public class DataGeneratorTest {
     private final static String INPUT_SCHEMA_CONTAINS_CODEPOINT_LENGTH = "./tst/com/amazon/ion/benchmark/testStringCodepointLength.isl";
     private final static String INPUT_ION_STRUCT_SCHEMA_CONTAINS_ELEMENT_FILE_PATH = "./tst/com/amazon/ion/benchmark/testSchemaContainsElement.isl";
     private final static String INPUT_ION_SEXP_FILE_PATH = "./tst/com/amazon/ion/benchmark/testSexp.isl";
+    private final static String INPUT_ION_INT_SCHEMA = "./tst/com/amazon/ion/benchmark/testIntWithoutConstraint.isl";
     private final static String INPUT_TEST_ELEMENT_SCHEMA = "./tst/com/amazon/ion/benchmark/testElement.isl";
     private final static String INPUT_ION_CLOB_FILE_PATH = "./tst/com/amazon/ion/benchmark/testClob.isl";
     private final static String INPUT_ION_BLOB_FILE_PATH = "./tst/com/amazon/ion/benchmark/testBlob.isl";
@@ -220,6 +221,15 @@ public class DataGeneratorTest {
     @Test
     public void testViolationOfNestedIonList() throws Exception {
         DataGeneratorTest.violationDetect(INPUT_NESTED_ION_LIST_PATH);
+    }
+
+    /**
+     * Test if there's violation detected when generating IonInt from ISL without constraint.
+     * @throws Exception if error occurs during the violation detecting process.
+     */
+    @Test
+    public void testViolationOfIonInt() throws Exception {
+        DataGeneratorTest.violationDetect(INPUT_ION_INT_SCHEMA);
     }
 
     /**

--- a/tst/com/amazon/ion/benchmark/testIntWithoutConstraint.isl
+++ b/tst/com/amazon/ion/benchmark/testIntWithoutConstraint.isl
@@ -1,0 +1,4 @@
+type::{
+    name: Int,
+    type: int,
+}


### PR DESCRIPTION
*Issue #, if available:*
[ Adds internal default constraints in Ion Data Generator.](https://github.com/amzn/ion-java-benchmark-cli/issues/39)

*Description of changes:*

In order to generate data which is able to mimic the real-world data better, this PR updated default constraints of `String`, `Symbol`, `Timestamp` and `Int`.

**DataConstructor.java:**

- getCodePoint:
According to ASCII, in this method we added logic to narrow the `unicode` code point of generated character to the ranges `[65, 90]` and `[97, 122]` which matches to the character `[A-Z]` and `[a-z]`.
- constructInt:
Added logic to generate integers which are mostly conformed with the range `[0, 1024]`.
- constructTimestamp:
Updated the default precision of generated timestamp as `Day`.

**Test:**

- Added unit test for IonInt generating when there is no constraint provided in ISL.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
