### PR TITLE
Adds features to process constraints 'any_of' and 'one_of'.

### DIFF
--- a/src/com/amazon/ion/benchmark/DataConstructor.java
+++ b/src/com/amazon/ion/benchmark/DataConstructor.java
@@ -37,6 +37,7 @@ import com.amazon.ion.benchmark.schema.constraints.Range;
 import com.amazon.ion.benchmark.schema.constraints.Regex;
 import com.amazon.ion.benchmark.schema.constraints.ReparsedConstraint;
 import com.amazon.ion.benchmark.schema.constraints.TimestampPrecision;
+import com.amazon.ion.benchmark.schema.constraints.TypeName;
 import com.amazon.ion.benchmark.schema.constraints.ValidValues;
 import com.amazon.ion.system.IonBinaryWriterBuilder;
 import com.amazon.ion.system.IonReaderBuilder;
@@ -216,13 +217,13 @@ class DataConstructor {
         constraintMapClone.putAll(constraintMap);
         ValidValues validValues = (ValidValues) constraintMap.get("valid_values");
         Annotations annotations = (Annotations)constraintMapClone.remove("annotations");
+        TypeName type = (TypeName)constraintMapClone.remove("type");
         if (validValues != null && !validValues.isRange()) {
             result = getRandomValueFromList(validValues.getValidValues());
-        } else if (parsedTypeDefinition.getIonType() == null) {
+        } else if (type == null) {
             throw new IllegalStateException("Constraint 'type' is required.");
         } else {
-            IonType type = parsedTypeDefinition.getIonType();
-            switch (type) {
+            switch (type.getTypeName()) {
                 case FLOAT:
                     result = SYSTEM.newFloat(constructFloat(constraintMapClone));
                     break;

--- a/src/com/amazon/ion/benchmark/ReadGeneralConstraints.java
+++ b/src/com/amazon/ion/benchmark/ReadGeneralConstraints.java
@@ -35,14 +35,13 @@ public class ReadGeneralConstraints {
         // If more constraints added, here is the point where developers should start.
         Type schemaType = schema.getTypes().next();
         IonStruct constraintStruct = (IonStruct)schemaType.getIsl();
-        ReparsedType parsedTypeDefinition = new ReparsedType(constraintStruct);
         CountingOutputStream outputStreamCounter = new CountingOutputStream(new FileOutputStream(outputFile));
         try (IonWriter writer = formatWriter(format, outputStreamCounter)) {
             int count = 0;
             long currentSize = 0;
             // Determine how many values should be written before the writer.flush(), and this process aims to reduce the execution time of writer.flush().
             while (currentSize <= 0.05 * size) {
-                IonValue constructedData = DataConstructor.constructIonData(parsedTypeDefinition);
+                IonValue constructedData = DataConstructor.constructIonData(new ReparsedType(constraintStruct));
                 constructedData.writeTo(writer);
                 count ++;
                 writer.flush();
@@ -50,7 +49,7 @@ public class ReadGeneralConstraints {
             }
             while (currentSize <= size) {
                 for (int i = 0; i < count; i++) {
-                    IonValue constructedData = DataConstructor.constructIonData(parsedTypeDefinition);
+                    IonValue constructedData = DataConstructor.constructIonData(new ReparsedType(constraintStruct));
                     constructedData.writeTo(writer);
                 }
                 writer.flush();

--- a/src/com/amazon/ion/benchmark/schema/constraints/TypeName.java
+++ b/src/com/amazon/ion/benchmark/schema/constraints/TypeName.java
@@ -1,0 +1,33 @@
+package com.amazon.ion.benchmark.schema.constraints;
+
+import com.amazon.ion.IonType;
+import com.amazon.ion.IonValue;
+
+public class TypeName implements ReparsedConstraint {
+    private IonType typeName;
+
+    /**
+     * Initializing the newly created TypeName object.
+     * @param field represents the value of constraint 'type'.
+     */
+    private TypeName(IonValue field) {
+        this.typeName = IonType.valueOf(field.toString().toUpperCase());
+    }
+
+    /**
+     * Helping access the private attribute 'type'.
+     * @return the attribute 'type'.
+     */
+    public IonType getTypeName() {
+        return this.typeName;
+    }
+
+    /**
+     * Parsing the value of constraint 'type' into TypeName.
+     * @param field represents the value of constraint 'type'.
+     * @return the parsed object TypeName.
+     */
+    public static TypeName of(IonValue field) {
+        return new TypeName(field);
+    }
+}

--- a/src/com/amazon/ion/benchmark/schema/constraints/TypeName.java
+++ b/src/com/amazon/ion/benchmark/schema/constraints/TypeName.java
@@ -3,6 +3,9 @@ package com.amazon.ion.benchmark.schema.constraints;
 import com.amazon.ion.IonType;
 import com.amazon.ion.IonValue;
 
+/**
+ * This class is used for parsing the value of constraint 'type' to object TypeName, and the attribute of this object represents the 'type_name' in IonType format.
+ */
 public class TypeName implements ReparsedConstraint {
     private IonType typeName;
 

--- a/tst/com/amazon/ion/benchmark/DataGeneratorTest.java
+++ b/tst/com/amazon/ion/benchmark/DataGeneratorTest.java
@@ -60,6 +60,8 @@ public class DataGeneratorTest {
     private final static String INPUT_SCHEMA_CONTAINS_ANNOTATIONS = "./tst/com/amazon/ion/datagenerator/testAnnotations.isl";
     private final static String INPUT_ION_STRING_FILE_PATH = "./tst/com/amazon/ion/datagenerator/testString.isl";
     private final static String INPUT_ION_INT_FILE_PATH = "./tst/com/amazon/ion/datagenerator/testInt.isl";
+    private final static String INPUT_SCHEMA_WITH_ANY_OF = "./tst/com/amazon/ion/datagenerator/testAnyOf.isl";
+    private final static String INPUT_SCHEMA_WITH_ONE_OF = "./tst/com/amazon/ion/datagenerator/testOneOf.isl";
     private final static String SCORE_DIFFERENCE = "scoreDifference";
     private final static String COMPARISON_REPORT_WITHOUT_REGRESSION = "./tst/com/amazon/ion/workflow/testComparisonReportWithoutRegression.ion";
     private final static String COMPARISON_REPORT = "./tst/com/amazon/ion/workflow/testComparisonReport.ion";
@@ -140,6 +142,24 @@ public class DataGeneratorTest {
             byte[] buffer = Files.readAllBytes(path);
             assertEquals(Format.valueOf(format.toUpperCase()) == Format.ION_BINARY, IonStreamUtils.isIonBinary(buffer));
         }
+    }
+
+    /**
+     * Test if there's violation when generating ion data from the schema which contains constraint 'any_of'.
+     * @throws Exception if error occurs during violation detecting process.
+     */
+    @Test
+    public void testLogicConstraintAnyOf() throws Exception {
+        DataGeneratorTest.violationDetect(INPUT_SCHEMA_WITH_ANY_OF);
+    }
+
+    /**
+     * Test if there's violation when generating ion data from the schema which contains constraint 'one_of'.
+     * @throws Exception if error occurs during violation detecting process.
+     */
+    @Test
+    public void testLogicConstraintOneOf() throws Exception {
+        DataGeneratorTest.violationDetect(INPUT_SCHEMA_WITH_ONE_OF);
     }
 
     /**

--- a/tst/com/amazon/ion/datagenerator/testAnyOf.isl
+++ b/tst/com/amazon/ion/datagenerator/testAnyOf.isl
@@ -1,0 +1,21 @@
+type::{
+    name:any_of_test,
+    any_of:[
+        {
+            type:string,
+            codepoint_length:19
+        },
+        {
+            type:struct,
+            fields:{
+                    StartTime:{type:timestamp},
+                    'ACK.count':{type:string,codepoint_length:1},
+                    'ACK.re-msid':{type:string,codepoint_length:36}
+            }
+        }
+    ]
+}
+
+
+
+

--- a/tst/com/amazon/ion/datagenerator/testOneOf.isl
+++ b/tst/com/amazon/ion/datagenerator/testOneOf.isl
@@ -1,0 +1,21 @@
+type::{
+    name:one_of_test,
+    one_of:[
+        {
+            type:string,
+            codepoint_length:19
+        },
+        int,
+        {
+            type:struct,
+            fields: {
+                Operation:{one_of:[{type:string,codepoint_length:range::[6,16]},symbol]},
+                PID:{one_of:[{type:string,codepoint_length:59},symbol]}
+            }
+        }
+    ]
+}
+
+
+
+


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This PR adds logic to process the constraints `any_of` and `one_of` and adds the relative unit tests for the new features.

**ReadGeneralConstraints.java:**
Constructing `ReparsedType` object every time we call the method of constructing `IonData`. In this case, if there is constraint `any_of` or `one_of` in the schema, the attributes (`constraintMap`) of  `ReparsedType` will be reconstructed/updated and be aligned with the content of the current type reference.

**DataConstructor.java:**
Changing the strategy of getting` type_name` of the current `type_reference`. This change is aligned with the update of `ReparsedType.java`.

**ReparsedType.java:**

- Adds logic to parse the value of constraint ‘type’ to TypeName object then construct key value pair of `<type, ReparsedConstraint>` then add it to the `constraintMap` which will be passed to the data constructing process. The reason of replacing the original static method `getType` to the current strategy is to make sure the type name passed into the data constructing process is accurate and up-to-date. After adding the logic of processing constraints `any_of`/ `one_of` (the value of these fields is list of the `type_reference`), each `type_reference` will be parsed as `ReparsedType`. Adding the `TypeName` key value pair as one of the constraint in `constraintMap` will make the current `TypeName` aligned with the value of constraint `type` in the type reference.

- handleField:
Adds logic to process the constraints `one_of` and `any_of`. According to Ion Schema Specification, the definition of `[any_of](https://amzn.github.io/ion-schema/docs/spec.html#any_of)` is different from `[one_of](https://amzn.github.io/ion-schema/docs/spec.html#one_of)` while validating ion data. However, in term of generating ion data from schema, these two constraints have the same functionality and would share the same logic. The value of constraint `any_of`/`one_of` is a list of `type_reference`, and one of the `type_reference` will be randomly chosen and then will be parsed to `ReparsedType`. The constraints contained in the randomly picked `type_reference` will be added to the top level `constraintMap` which will be used in the following data constructing process.

- Adds case of processing constraint `content`. When using Dataguide to infer schema from real-world data, the type definition of struct contains `content: closed`. For this constraint, there is no additional logic needed for the following data constructing process.

**TypeName.java:**
This class is used for parsing the value of constraint `type` as `TypeName`, and the attribute of this object represents the type name in `IonType` format.

**Test:**
Adds tests for the feature of processing constraints `any_of` and `one_of`.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
