### PR TITLE
Updates the default value of constraint 'occurs'.

### DIFF
--- a/src/com/amazon/ion/benchmark/DataConstructor.java
+++ b/src/com/amazon/ion/benchmark/DataConstructor.java
@@ -302,8 +302,7 @@ class DataConstructor {
                 // Get the type definition for each field.
                 ReparsedType fieldTypeDefinition = entry.getValue();
                 // 'occurs' included in the field constraint determines the occurrences of the specified field.
-                int occurs = ReparsedType.getOccurs(fieldTypeDefinition.getConstraintStruct());
-                int occurTime = occurs == -1 ? random.nextInt(2) : occurs;
+                int occurTime = ReparsedType.getOccurs(fieldTypeDefinition.getConstraintStruct());
                 for (int i = 0; i < occurTime; i++) {
                     constructedIonStruct.add(entry.getKey(), constructIonData(fieldTypeDefinition));
                 }
@@ -343,8 +342,7 @@ class DataConstructor {
             ArrayList<ReparsedType> orderedElementsConstraints = elementsConstraints.getOrderedElementsConstraints();
             for (ReparsedType constraint : orderedElementsConstraints) {
                 // 'occurs' included in the constraint of 'ordered_element' indicates the occurrences of the specified element.
-                int occurs = ReparsedType.getOccurs(constraint.getConstraintStruct());
-                int occurTime = occurs == -1 ? 1 : occurs;
+                int occurTime = ReparsedType.getOccurs(constraint.getConstraintStruct());
                 for (int i = 0; i < occurTime; i++) {
                     container.add(constructIonData(constraint));
                 }

--- a/src/com/amazon/ion/benchmark/schema/ReparsedType.java
+++ b/src/com/amazon/ion/benchmark/schema/ReparsedType.java
@@ -99,7 +99,7 @@ public class ReparsedType {
         // For constraint Field, the default value of occurs is optional.
         // For constraint ordered_elements, the default value of occurs is required.
         if (occursValue == null) {
-            return -1;
+            return 1;
         } else {
             Occurs occurs = Occurs.of(occursValue);
             return occurs.getOccurRange().getRandomQuantifiableValueFromRange().intValue();


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/amzn/ion-java-benchmark-cli/issues/46

*Description of changes:*

This PR updates the default value of constraint `occurs`.  According to [Ion Schema Specification](https://amzn.github.io/ion-schema/docs/spec/isl-1-0-spec.html), `occurs` indicates how many times a specific value may occur and this is only applicable only within the context of `ordered_elements` and struct `fields` constraints. Before updating, the default value of `occurs` is `optional` when it is within the context of constraint `fields`. However it would cause the issue https://github.com/amzn/ion-java-benchmark-cli/issues/46. Then we decide to update the `occurs` default value to `required` (the value it specified must occur once).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
