### PR TITLE
Adds option to allow generate the same random data.

### DIFF
--- a/src/com/amazon/ion/benchmark/DataConstructor.java
+++ b/src/com/amazon/ion/benchmark/DataConstructor.java
@@ -292,7 +292,7 @@ class DataConstructor {
         } else if (element != null) {
             int length = container_length == null ? DEFAULT_CONTAINER_LENGTH : container_length.getRange().getRandomQuantifiableValueFromRange().intValue();
             for (int i = 0; i < length; i++) {
-                constructedIonStruct.add(constructStringFromCodepointLength(GeneratorOptions.randomSeed.nextInt(20)), constructIonData(element.getElement()));
+                constructedIonStruct.add(constructStringFromCodepointLength(GeneratorOptions.random.nextInt(20)), constructIonData(element.getElement()));
             }
         } else {
             Map<String, ReparsedType> fieldMap = fields.getFieldMap();
@@ -378,14 +378,14 @@ class DataConstructor {
         } else if (regex != null) {
             String pattern = regex.getPattern();
             RgxGen rgxGen = new RgxGen(pattern);
-            return rgxGen.generate(GeneratorOptions.randomSeed);
+            return rgxGen.generate(GeneratorOptions.random);
         } else if (codepoint_length != null) {
             int length = codepoint_length.getRange().getRandomQuantifiableValueFromRange().intValue();
             return constructStringFromCodepointLength(length);
         } else {
             // If there is no constraints provided, a randomly constructed string with
             // preset Unicode codepoints length will be generated.
-            return constructStringFromCodepointLength(GeneratorOptions.randomSeed.nextInt(20));
+            return constructStringFromCodepointLength(GeneratorOptions.random.nextInt(20));
         }
     }
 
@@ -394,8 +394,8 @@ class DataConstructor {
      * @return generated codepoint.
      */
     private static int getCodePoint() {
-        int index = GeneratorOptions.randomSeed.nextInt(20);
-        int randomIndex = GeneratorOptions.randomSeed.nextInt(26);
+        int index = GeneratorOptions.random.nextInt(20);
+        int randomIndex = GeneratorOptions.random.nextInt(26);
         if (index < 10) {
             // Randomly generate the unicode of character from [A-Z].
             return randomIndex + ASCII_CODE_UPPERCASE_A;
@@ -436,7 +436,7 @@ class DataConstructor {
         if (validValues != null) {
             return validValues.getRange().getRandomQuantifiableValueFromRange().doubleValue();
         } else {
-            return GeneratorOptions.randomSeed.nextDouble();
+            return GeneratorOptions.random.nextDouble();
         }
     }
 
@@ -448,13 +448,13 @@ class DataConstructor {
      */
     public static BigDecimal constructDecimal(Map<String, ReparsedConstraint> constraintMapClone) {
         // If there is no constraints provided, assign scale and precision with default values.
-        int scaleValue = GeneratorOptions.randomSeed.nextInt(DEFAULT_SCALE_UPPER_BOUND - DEFAULT_SCALE_LOWER_BOUND + 1) + DEFAULT_SCALE_LOWER_BOUND;
-        int precisionValue = GeneratorOptions.randomSeed.nextInt(DEFAULT_PRECISION);
+        int scaleValue = GeneratorOptions.random.nextInt(DEFAULT_SCALE_UPPER_BOUND - DEFAULT_SCALE_LOWER_BOUND + 1) + DEFAULT_SCALE_LOWER_BOUND;
+        int precisionValue = GeneratorOptions.random.nextInt(DEFAULT_PRECISION);
         QuantifiableConstraints scale = (QuantifiableConstraints) constraintMapClone.remove("scale");
         QuantifiableConstraints precision = (QuantifiableConstraints) constraintMapClone.remove("precision");
         ValidValues validValues = (ValidValues) constraintMapClone.remove("valid_values");
         StringBuilder rs = new StringBuilder();
-        rs.append(GeneratorOptions.randomSeed.nextInt(9) + 1);
+        rs.append(GeneratorOptions.random.nextInt(9) + 1);
         if (!constraintMapClone.isEmpty()) {
             throw new IllegalStateException ("Found unhandled constraints : " + constraintMapClone.values());
         }
@@ -466,7 +466,7 @@ class DataConstructor {
                 precisionValue = precision.getRange().getRandomQuantifiableValueFromRange().intValue();
             }
             for (int digit = 1; digit < precisionValue; digit++) {
-                rs.append(GeneratorOptions.randomSeed.nextInt(10));
+                rs.append(GeneratorOptions.random.nextInt(10));
             }
             BigInteger unscaledValue = new BigInteger(rs.toString());
             return new BigDecimal(unscaledValue, scaleValue);
@@ -499,11 +499,11 @@ class DataConstructor {
             // If there is no constraint provided, the generator will construct a random value.
             // Randomly generate integers in the distribution that more than 80% of integers would be smaller than 1024.
             // In this case, the generated integers would be more similar to the real world data.
-            int index = GeneratorOptions.randomSeed.nextInt(20);
+            int index = GeneratorOptions.random.nextInt(20);
             if (index < 16) {
-                return GeneratorOptions.randomSeed.nextInt(1024);
+                return GeneratorOptions.random.nextInt(1024);
             } else {
-                return GeneratorOptions.randomSeed.nextLong();
+                return GeneratorOptions.random.nextLong();
             }
         }
     }
@@ -517,7 +517,7 @@ class DataConstructor {
     public static Timestamp constructTimestamp(Map<String, ReparsedConstraint> constraintMapClone) {
         Range range = DEFAULT_TIMESTAMP_IN_MILLIS_DECIMAL_RANGE;
         // Preset the local offset.
-        Integer localOffset = localOffset(GeneratorOptions.randomSeed);
+        Integer localOffset = localOffset(GeneratorOptions.random);
         // Preset the default precision as 'Day'.
         Timestamp.Precision precision = Timestamp.Precision.DAY;
         TimestampPrecision timestampPrecision = (TimestampPrecision) constraintMapClone.remove("timestamp_precision");
@@ -569,10 +569,10 @@ class DataConstructor {
         if (byteLength != null) {
             byte_length = byteLength.getRange().getRandomQuantifiableValueFromRange().intValue();
         } else {
-            byte_length = GeneratorOptions.randomSeed.nextInt(512);
+            byte_length = GeneratorOptions.random.nextInt(512);
         }
         byte[] randomBytes = new byte[byte_length];
-        GeneratorOptions.randomSeed.nextBytes(randomBytes);
+        GeneratorOptions.random.nextBytes(randomBytes);
         return randomBytes;
     }
 

--- a/src/com/amazon/ion/benchmark/DataConstructor.java
+++ b/src/com/amazon/ion/benchmark/DataConstructor.java
@@ -282,7 +282,6 @@ class DataConstructor {
         Fields fields = (Fields)constraintMapClone.remove("fields");
         Element element = (Element)constraintMapClone.remove("element");
         QuantifiableConstraints container_length = (QuantifiableConstraints)constraintMapClone.remove("container_length");
-        Random random = new Random();
         IonStruct constructedIonStruct = SYSTEM.newEmptyStruct();
         // Check if there is unhandled constraint provided.
         if (!constraintMapClone.isEmpty()) {
@@ -293,7 +292,7 @@ class DataConstructor {
         } else if (element != null) {
             int length = container_length == null ? DEFAULT_CONTAINER_LENGTH : container_length.getRange().getRandomQuantifiableValueFromRange().intValue();
             for (int i = 0; i < length; i++) {
-                constructedIonStruct.add(constructStringFromCodepointLength(random.nextInt(20)), constructIonData(element.getElement()));
+                constructedIonStruct.add(constructStringFromCodepointLength(GeneratorOptions.randomSeed.nextInt(20)), constructIonData(element.getElement()));
             }
         } else {
             Map<String, ReparsedType> fieldMap = fields.getFieldMap();
@@ -369,7 +368,6 @@ class DataConstructor {
      * @return constructed string.
      */
     public static String constructString(Map<String, ReparsedConstraint> constraintMapClone) {
-        Random random = new Random();
         Regex regex = (Regex) constraintMapClone.remove("regex");
         QuantifiableConstraints codepoint_length = (QuantifiableConstraints) constraintMapClone.remove("codepoint_length");
         if (!constraintMapClone.isEmpty()) {
@@ -380,14 +378,14 @@ class DataConstructor {
         } else if (regex != null) {
             String pattern = regex.getPattern();
             RgxGen rgxGen = new RgxGen(pattern);
-            return rgxGen.generate();
+            return rgxGen.generate(GeneratorOptions.randomSeed);
         } else if (codepoint_length != null) {
             int length = codepoint_length.getRange().getRandomQuantifiableValueFromRange().intValue();
             return constructStringFromCodepointLength(length);
         } else {
             // If there is no constraints provided, a randomly constructed string with
             // preset Unicode codepoints length will be generated.
-            return constructStringFromCodepointLength(random.nextInt(20));
+            return constructStringFromCodepointLength(GeneratorOptions.randomSeed.nextInt(20));
         }
     }
 
@@ -396,8 +394,8 @@ class DataConstructor {
      * @return generated codepoint.
      */
     private static int getCodePoint() {
-        int index = ThreadLocalRandom.current().nextInt(20);
-        int randomIndex = ThreadLocalRandom.current().nextInt(26);
+        int index = GeneratorOptions.randomSeed.nextInt(20);
+        int randomIndex = GeneratorOptions.randomSeed.nextInt(26);
         if (index < 10) {
             // Randomly generate the unicode of character from [A-Z].
             return randomIndex + ASCII_CODE_UPPERCASE_A;
@@ -438,7 +436,7 @@ class DataConstructor {
         if (validValues != null) {
             return validValues.getRange().getRandomQuantifiableValueFromRange().doubleValue();
         } else {
-            return ThreadLocalRandom.current().nextDouble();
+            return GeneratorOptions.randomSeed.nextDouble();
         }
     }
 
@@ -449,15 +447,14 @@ class DataConstructor {
      * @return the constructed decimal.
      */
     public static BigDecimal constructDecimal(Map<String, ReparsedConstraint> constraintMapClone) {
-        Random random = new Random();
         // If there is no constraints provided, assign scale and precision with default values.
-        int scaleValue = random.nextInt(DEFAULT_SCALE_UPPER_BOUND - DEFAULT_SCALE_LOWER_BOUND + 1) + DEFAULT_SCALE_LOWER_BOUND;
-        int precisionValue = random.nextInt(DEFAULT_PRECISION);
+        int scaleValue = GeneratorOptions.randomSeed.nextInt(DEFAULT_SCALE_UPPER_BOUND - DEFAULT_SCALE_LOWER_BOUND + 1) + DEFAULT_SCALE_LOWER_BOUND;
+        int precisionValue = GeneratorOptions.randomSeed.nextInt(DEFAULT_PRECISION);
         QuantifiableConstraints scale = (QuantifiableConstraints) constraintMapClone.remove("scale");
         QuantifiableConstraints precision = (QuantifiableConstraints) constraintMapClone.remove("precision");
         ValidValues validValues = (ValidValues) constraintMapClone.remove("valid_values");
         StringBuilder rs = new StringBuilder();
-        rs.append(random.nextInt(9) + 1);
+        rs.append(GeneratorOptions.randomSeed.nextInt(9) + 1);
         if (!constraintMapClone.isEmpty()) {
             throw new IllegalStateException ("Found unhandled constraints : " + constraintMapClone.values());
         }
@@ -469,7 +466,7 @@ class DataConstructor {
                 precisionValue = precision.getRange().getRandomQuantifiableValueFromRange().intValue();
             }
             for (int digit = 1; digit < precisionValue; digit++) {
-                rs.append(random.nextInt(10));
+                rs.append(GeneratorOptions.randomSeed.nextInt(10));
             }
             BigInteger unscaledValue = new BigInteger(rs.toString());
             return new BigDecimal(unscaledValue, scaleValue);
@@ -502,12 +499,11 @@ class DataConstructor {
             // If there is no constraint provided, the generator will construct a random value.
             // Randomly generate integers in the distribution that more than 80% of integers would be smaller than 1024.
             // In this case, the generated integers would be more similar to the real world data.
-            Random random = new Random();
-            int index = random.nextInt(20);
+            int index = GeneratorOptions.randomSeed.nextInt(20);
             if (index < 16) {
-                return ThreadLocalRandom.current().nextInt(1024);
+                return GeneratorOptions.randomSeed.nextInt(1024);
             } else {
-                return ThreadLocalRandom.current().nextLong();
+                return GeneratorOptions.randomSeed.nextLong();
             }
         }
     }
@@ -519,10 +515,9 @@ class DataConstructor {
      * @return the constructed timestamp.
      */
     public static Timestamp constructTimestamp(Map<String, ReparsedConstraint> constraintMapClone) {
-        Random random = new Random();
         Range range = DEFAULT_TIMESTAMP_IN_MILLIS_DECIMAL_RANGE;
         // Preset the local offset.
-        Integer localOffset = localOffset(random);
+        Integer localOffset = localOffset(GeneratorOptions.randomSeed);
         // Preset the default precision as 'Day'.
         Timestamp.Precision precision = Timestamp.Precision.DAY;
         TimestampPrecision timestampPrecision = (TimestampPrecision) constraintMapClone.remove("timestamp_precision");
@@ -567,7 +562,6 @@ class DataConstructor {
      */
     public static byte[] constructLobs( Map<String, ReparsedConstraint> constraintMapClone) {
         int byte_length;
-        Random random = new Random();
         QuantifiableConstraints byteLength = (QuantifiableConstraints) constraintMapClone.remove("byte_length");
         if (!constraintMapClone.isEmpty()) {
             throw new IllegalStateException ("Found unhandled constraints : " + constraintMapClone.values());
@@ -575,10 +569,10 @@ class DataConstructor {
         if (byteLength != null) {
             byte_length = byteLength.getRange().getRandomQuantifiableValueFromRange().intValue();
         } else {
-            byte_length = random.nextInt(512);
+            byte_length = GeneratorOptions.randomSeed.nextInt(512);
         }
         byte[] randomBytes = new byte[byte_length];
-        random.nextBytes(randomBytes);
+        GeneratorOptions.randomSeed.nextBytes(randomBytes);
         return randomBytes;
     }
 

--- a/src/com/amazon/ion/benchmark/GeneratorOptions.java
+++ b/src/com/amazon/ion/benchmark/GeneratorOptions.java
@@ -10,7 +10,7 @@ import java.util.Random;
  * Execute Ion Data Generator after receiving the hashmap of command line options.
  */
 public class GeneratorOptions {
-    public static Random randomSeed;
+    public static Random random;
 
     /**
      * Check the validation of input ion schema and execute the Ion Data generating process.
@@ -23,9 +23,9 @@ public class GeneratorOptions {
         String path = optionsMap.get("<output_file>").toString();
         String inputFilePath = optionsMap.get("--input-ion-schema").toString();
         if (optionsMap.get("--seed") != null) {
-            randomSeed = new Random(Long.valueOf(optionsMap.get("--seed").toString()));
+            random = new Random(Long.valueOf(optionsMap.get("--seed").toString()));
         } else {
-            randomSeed = new Random();
+            random = new Random();
         }
         // Check whether the input schema file is valid and get the loaded schema.
         Schema schema = IonSchemaUtilities.loadSchemaDefinition(inputFilePath);

--- a/src/com/amazon/ion/benchmark/GeneratorOptions.java
+++ b/src/com/amazon/ion/benchmark/GeneratorOptions.java
@@ -4,11 +4,13 @@ import com.amazon.ionschema.Schema;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 
 /**
  * Execute Ion Data Generator after receiving the hashmap of command line options.
  */
 public class GeneratorOptions {
+    public static Random randomSeed;
 
     /**
      * Check the validation of input ion schema and execute the Ion Data generating process.
@@ -20,6 +22,11 @@ public class GeneratorOptions {
         String format = ((List<String>) optionsMap.get("--format")).get(0);
         String path = optionsMap.get("<output_file>").toString();
         String inputFilePath = optionsMap.get("--input-ion-schema").toString();
+        if (optionsMap.get("--seed") != null) {
+            randomSeed = new Random(Long.valueOf(optionsMap.get("--seed").toString()));
+        } else {
+            randomSeed = new Random();
+        }
         // Check whether the input schema file is valid and get the loaded schema.
         Schema schema = IonSchemaUtilities.loadSchemaDefinition(inputFilePath);
         ReadGeneralConstraints.constructAndWriteIonData(size, schema, format, path);

--- a/src/com/amazon/ion/benchmark/Main.java
+++ b/src/com/amazon/ion/benchmark/Main.java
@@ -252,7 +252,7 @@ public class Main {
             + "generated Ion data would conform with.\n"
 
         + "  -M --seed <long>      This option will be specified when users would like to get the same random data from the same schema file."
-            + "The provided value should be 64 bits of long seed value which will be used for creating pseudorandom number generator. \n"
+            + "The provided value should be up to 64 bits of long seed value, which will be used for creating a pseudorandom number generator. \n"
 
         // 'compare' options
 

--- a/src/com/amazon/ion/benchmark/Main.java
+++ b/src/com/amazon/ion/benchmark/Main.java
@@ -42,7 +42,7 @@ public class Main {
             + "[--ion-use-lob-chunks <bool>]... [--ion-use-big-decimals <bool>]... [--ion-reader-buffer-size <int>]... "
             + "[--json-use-big-decimals <bool>]... <input_file>\n"
         
-        + "  ion-java-benchmark generate (--data-size <data_size>) (--format <type>) (--input-ion-schema <file_path>) <output_file>\n"
+        + "  ion-java-benchmark generate [--seed <seed_value>] (--data-size <data_size>) (--format <type>) (--input-ion-schema <file_path>) <output_file>\n"
 
         + "  ion-java-benchmark compare (--benchmark-result-previous <file_path>) (--benchmark-result-new <file_path>) <output_file>\n"
 
@@ -250,6 +250,8 @@ public class Main {
 
         + "  -Q --input-ion-schema <file_path>      This option will specify the path of Ion Schema file which contains all constraints that the "
             + "generated Ion data would conform with.\n"
+
+        + "  -M --seed <seed_value>   This option will be specified when users would like to get the same random data from the same schema file.\n"
 
         // 'compare' options
 

--- a/src/com/amazon/ion/benchmark/Main.java
+++ b/src/com/amazon/ion/benchmark/Main.java
@@ -251,7 +251,8 @@ public class Main {
         + "  -Q --input-ion-schema <file_path>      This option will specify the path of Ion Schema file which contains all constraints that the "
             + "generated Ion data would conform with.\n"
 
-        + "  -M --seed <seed_value>   This option will be specified when users would like to get the same random data from the same schema file.\n"
+        + "  -M --seed <long>      This option will be specified when users would like to get the same random data from the same schema file."
+            + "The provided value should be 64 bits of long seed value which will be used for creating pseudorandom number generator. \n"
 
         // 'compare' options
 

--- a/src/com/amazon/ion/benchmark/ReadGeneralConstraints.java
+++ b/src/com/amazon/ion/benchmark/ReadGeneralConstraints.java
@@ -14,7 +14,6 @@ import com.amazon.ionschema.Type;
 
 import java.io.FileOutputStream;
 import java.io.OutputStream;
-import java.util.Random;
 
 /**
  * Parse Ion Schema file and extract the type definition as ReparsedType object then pass the re-parsed type definition to the Ion data generator.

--- a/src/com/amazon/ion/benchmark/ReadGeneralConstraints.java
+++ b/src/com/amazon/ion/benchmark/ReadGeneralConstraints.java
@@ -14,6 +14,7 @@ import com.amazon.ionschema.Type;
 
 import java.io.FileOutputStream;
 import java.io.OutputStream;
+import java.util.Random;
 
 /**
  * Parse Ion Schema file and extract the type definition as ReparsedType object then pass the re-parsed type definition to the Ion data generator.
@@ -32,7 +33,6 @@ public class ReadGeneralConstraints {
      */
     public static void constructAndWriteIonData(int size, Schema schema, String format, String outputFile) throws Exception {
         // Assume there's only one type definition between schema_header and schema_footer.
-        // If more constraints added, here is the point where developers should start.
         Type schemaType = schema.getTypes().next();
         IonStruct constraintStruct = (IonStruct)schemaType.getIsl();
         CountingOutputStream outputStreamCounter = new CountingOutputStream(new FileOutputStream(outputFile));

--- a/src/com/amazon/ion/benchmark/schema/ReparsedType.java
+++ b/src/com/amazon/ion/benchmark/schema/ReparsedType.java
@@ -4,6 +4,7 @@ import com.amazon.ion.IonList;
 import com.amazon.ion.IonStruct;
 import com.amazon.ion.IonType;
 import com.amazon.ion.IonValue;
+import com.amazon.ion.benchmark.GeneratorOptions;
 import com.amazon.ion.benchmark.IonSchemaUtilities;
 import com.amazon.ion.benchmark.schema.constraints.Annotations;
 import com.amazon.ion.benchmark.schema.constraints.Contains;
@@ -19,7 +20,6 @@ import com.amazon.ion.benchmark.schema.constraints.ValidValues;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
 
 // Parsing the type definition in ISL file into ReparsedType format which allows getting constraints information directly.
 public class ReparsedType {
@@ -76,9 +76,8 @@ public class ReparsedType {
                 return;
             case KEYWORD_ANY_OF:
             case KEYWORD_ONE_OF:
-                Random random = new Random();
                 IonList typeReferenceList = (IonList)field;
-                int index = random.nextInt(typeReferenceList.size());
+                int index = GeneratorOptions.randomSeed.nextInt(typeReferenceList.size());
                 IonValue chosenItem = typeReferenceList.get(index);
                 ReparsedType reparsedType = IonSchemaUtilities.parseTypeReference(chosenItem);
                 constraintMap.putAll(reparsedType.getConstraintMap());

--- a/src/com/amazon/ion/benchmark/schema/ReparsedType.java
+++ b/src/com/amazon/ion/benchmark/schema/ReparsedType.java
@@ -77,7 +77,7 @@ public class ReparsedType {
             case KEYWORD_ANY_OF:
             case KEYWORD_ONE_OF:
                 IonList typeReferenceList = (IonList)field;
-                int index = GeneratorOptions.randomSeed.nextInt(typeReferenceList.size());
+                int index = GeneratorOptions.random.nextInt(typeReferenceList.size());
                 IonValue chosenItem = typeReferenceList.get(index);
                 ReparsedType reparsedType = IonSchemaUtilities.parseTypeReference(chosenItem);
                 constraintMap.putAll(reparsedType.getConstraintMap());

--- a/src/com/amazon/ion/benchmark/schema/constraints/Annotations.java
+++ b/src/com/amazon/ion/benchmark/schema/constraints/Annotations.java
@@ -56,7 +56,7 @@ public class Annotations implements ReparsedConstraint {
      * @return a null value or a list of annotations randomly.
      */
     private IonList randomlyReturnAnnotations(IonValue field) {
-        int value = GeneratorOptions.randomSeed.nextInt(2);
+        int value = GeneratorOptions.random.nextInt(2);
         switch (value) {
             case 1:
                 return (IonList)field;

--- a/src/com/amazon/ion/benchmark/schema/constraints/Annotations.java
+++ b/src/com/amazon/ion/benchmark/schema/constraints/Annotations.java
@@ -2,9 +2,7 @@ package com.amazon.ion.benchmark.schema.constraints;
 
 import com.amazon.ion.IonList;
 import com.amazon.ion.IonValue;
-
-import java.util.Arrays;
-import java.util.Random;
+import com.amazon.ion.benchmark.GeneratorOptions;
 
 /**
  * This class aims to process the constraint 'annotations'. After parsing the constraint value to Annotations object, we
@@ -58,8 +56,7 @@ public class Annotations implements ReparsedConstraint {
      * @return a null value or a list of annotations randomly.
      */
     private IonList randomlyReturnAnnotations(IonValue field) {
-        Random random = new Random();
-        int value = random.nextInt(2);
+        int value = GeneratorOptions.randomSeed.nextInt(2);
         switch (value) {
             case 1:
                 return (IonList)field;

--- a/src/com/amazon/ion/benchmark/schema/constraints/Range.java
+++ b/src/com/amazon/ion/benchmark/schema/constraints/Range.java
@@ -85,6 +85,6 @@ public class Range {
         IonValue upperBound = sequence.get(1);
         BigDecimal lowerBoundBigDecimal = lowerBound.getType().equals(IonType.TIMESTAMP) ? ((IonTimestamp)lowerBound).getDecimalMillis() : new BigDecimal(lowerBound.toString());
         BigDecimal upperBoundBigDecimal = upperBound.getType().equals(IonType.TIMESTAMP) ? ((IonTimestamp)upperBound).getDecimalMillis() : new BigDecimal(upperBound.toString());
-        return lowerBoundBigDecimal.add(new BigDecimal(GeneratorOptions.randomSeed.nextDouble()).multiply(upperBoundBigDecimal.subtract(lowerBoundBigDecimal)));
+        return lowerBoundBigDecimal.add(new BigDecimal(GeneratorOptions.random.nextDouble()).multiply(upperBoundBigDecimal.subtract(lowerBoundBigDecimal)));
     }
 }

--- a/src/com/amazon/ion/benchmark/schema/constraints/Range.java
+++ b/src/com/amazon/ion/benchmark/schema/constraints/Range.java
@@ -5,10 +5,10 @@ import com.amazon.ion.IonSequence;
 import com.amazon.ion.IonTimestamp;
 import com.amazon.ion.IonType;
 import com.amazon.ion.IonValue;
+import com.amazon.ion.benchmark.GeneratorOptions;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
-import java.util.Random;
 
 // Processing the constraint value which contains 'range' annotation.
 public class Range {
@@ -81,11 +81,10 @@ public class Range {
      * @return a BigDecimal which is within the provided range. This value would be cast into different data types as needed.
      */
     public BigDecimal getRandomQuantifiableValueFromRange() {
-        Random random = new Random();
         IonValue lowerBound = sequence.get(0);
         IonValue upperBound = sequence.get(1);
         BigDecimal lowerBoundBigDecimal = lowerBound.getType().equals(IonType.TIMESTAMP) ? ((IonTimestamp)lowerBound).getDecimalMillis() : new BigDecimal(lowerBound.toString());
         BigDecimal upperBoundBigDecimal = upperBound.getType().equals(IonType.TIMESTAMP) ? ((IonTimestamp)upperBound).getDecimalMillis() : new BigDecimal(upperBound.toString());
-        return lowerBoundBigDecimal.add(new BigDecimal(random.nextDouble()).multiply(upperBoundBigDecimal.subtract(lowerBoundBigDecimal)));
+        return lowerBoundBigDecimal.add(new BigDecimal(GeneratorOptions.randomSeed.nextDouble()).multiply(upperBoundBigDecimal.subtract(lowerBoundBigDecimal)));
     }
 }

--- a/src/com/amazon/ion/benchmark/schema/constraints/TimestampPrecision.java
+++ b/src/com/amazon/ion/benchmark/schema/constraints/TimestampPrecision.java
@@ -1,9 +1,10 @@
 package com.amazon.ion.benchmark.schema.constraints;
 
-import com.amazon.ion.*;
+import com.amazon.ion.IonSequence;
+import com.amazon.ion.IonValue;
+import com.amazon.ion.Timestamp;
+import com.amazon.ion.benchmark.GeneratorOptions;
 import com.amazon.ion.benchmark.IonSchemaUtilities;
-
-import java.util.Random;
 
 public class TimestampPrecision extends QuantifiableConstraints{
 
@@ -30,14 +31,13 @@ public class TimestampPrecision extends QuantifiableConstraints{
      * @return randomly generated Timestamp.Precision.
      */
     public static Timestamp.Precision getRandomTimestampPrecision(Range range) {
-        Random random = new Random();
         IonSequence constraintSequence = range.getSequence();
         Timestamp.Precision[] precisions = Timestamp.Precision.values();
         String lowerBound = constraintSequence.get(0).toString();
         String upperBound = constraintSequence.get(1).toString();
         int lowerBoundOrdinal = lowerBound.equals(IonSchemaUtilities.KEYWORD_MIN) ? 0 : Timestamp.Precision.valueOf(lowerBound.toUpperCase()).ordinal();
         int upperBoundOrdinal = upperBound.equals(IonSchemaUtilities.KEYWORD_MAX) ? precisions.length : Timestamp.Precision.valueOf(upperBound.toUpperCase()).ordinal();
-        int randomIndex = random.nextInt(upperBoundOrdinal - lowerBoundOrdinal + 1) + lowerBoundOrdinal;
+        int randomIndex = GeneratorOptions.randomSeed.nextInt(upperBoundOrdinal - lowerBoundOrdinal + 1) + lowerBoundOrdinal;
         return precisions[randomIndex];
     }
 }

--- a/src/com/amazon/ion/benchmark/schema/constraints/TimestampPrecision.java
+++ b/src/com/amazon/ion/benchmark/schema/constraints/TimestampPrecision.java
@@ -37,7 +37,7 @@ public class TimestampPrecision extends QuantifiableConstraints{
         String upperBound = constraintSequence.get(1).toString();
         int lowerBoundOrdinal = lowerBound.equals(IonSchemaUtilities.KEYWORD_MIN) ? 0 : Timestamp.Precision.valueOf(lowerBound.toUpperCase()).ordinal();
         int upperBoundOrdinal = upperBound.equals(IonSchemaUtilities.KEYWORD_MAX) ? precisions.length : Timestamp.Precision.valueOf(upperBound.toUpperCase()).ordinal();
-        int randomIndex = GeneratorOptions.randomSeed.nextInt(upperBoundOrdinal - lowerBoundOrdinal + 1) + lowerBoundOrdinal;
+        int randomIndex = GeneratorOptions.random.nextInt(upperBoundOrdinal - lowerBoundOrdinal + 1) + lowerBoundOrdinal;
         return precisions[randomIndex];
     }
 }

--- a/tst/com/amazon/ion/benchmark/DataGeneratorTest.java
+++ b/tst/com/amazon/ion/benchmark/DataGeneratorTest.java
@@ -3,6 +3,7 @@ package com.amazon.ion.benchmark;
 import com.amazon.ion.IonDatagram;
 import com.amazon.ion.IonDecimal;
 import com.amazon.ion.IonFloat;
+import com.amazon.ion.IonLoader;
 import com.amazon.ion.IonReader;
 import com.amazon.ion.IonStruct;
 import com.amazon.ion.IonSystem;
@@ -16,6 +17,7 @@ import com.amazon.ionschema.Schema;
 import com.amazon.ionschema.Type;
 import com.amazon.ionschema.Violations;
 
+import java.io.File;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
@@ -23,6 +25,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.junit.After;
 import org.junit.Test;
 
@@ -35,12 +38,13 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
 
 public class DataGeneratorTest {
     private static String outputFile = null;
     private final static IonSystem SYSTEM = IonSystemBuilder.standard().build();
+    private final static IonLoader LOADER = SYSTEM.newLoader();
     private final static String INPUT_ION_STRUCT_FILE_PATH = "./tst/com/amazon/ion/datagenerator/testStruct.isl";
     private final static String INPUT_ION_LIST_FILE_PATH = "./tst/com/amazon/ion/datagenerator/testList.isl";
     private final static String INPUT_NESTED_ION_LIST_PATH = "./tst/com/amazon/ion/datagenerator/testNestedList.isl";
@@ -76,6 +80,9 @@ public class DataGeneratorTest {
     private final static String HEAP_USAGE = "Heap usage";
     private final static String SERIALIZED_SIZE = "Serialized size";
     private final static String SPEED = "speed";
+    private final static File[] TEST_ISL_FILES = new File("./tst/com/amazon/ion/datagenerator/").listFiles();
+    private final static String BEFORE = "testSeed0.ion";
+    private final static String AFTER = "testSeed1.ion";
 
     /**
      * Construct IonReader for current output file in order to finish the following test process.
@@ -124,6 +131,43 @@ public class DataGeneratorTest {
                 assertTrue("Violations " + violations + "found in value " + value, violations.isValid());
             }
         }
+    }
+
+    /**
+     * This method executes Ion Data Generation twice and compare the generated data then provide the comparison result which represents by the boolean value.
+     * @param seedOption represents whether the '--seed' option is specified. If it is specified, the value of this option is 'true'. Otherwise, the value is 'false'.
+     * @return Boolean value which represents the comparison result. If there is any difference between two generated ion files, the return value will be set to 'false'.
+     * @throws Exception if there is error when executing data generation.
+     */
+    public Boolean generateAndCompare(Boolean seedOption) throws Exception {
+        Boolean result = true;
+        for (File testFile : TEST_ISL_FILES) {
+            String testFilePath = testFile.getPath();
+            for (int i = 0; i < 2; i++) {
+                String outputFile = "testSeed" + i + ".ion";
+                Map <String, Object> optionsMap = Main.parseArguments("generate", "--data-size", "5000", "--format", "ion_text", "--input-ion-schema", testFilePath, outputFile);
+                if (seedOption == true) {
+                    optionsMap = Main.parseArguments("generate", "--data-size", "5000", "--seed", "200", "--format", "ion_text", "--input-ion-schema", testFilePath, outputFile);
+                }
+                GeneratorOptions.executeGenerator(optionsMap);
+            }
+            IonDatagram datagramBefore = LOADER.load(new FileInputStream(BEFORE));
+            IonDatagram datagramAfter = LOADER.load(new FileInputStream(AFTER));
+            if (datagramBefore.size() == datagramAfter.size()) {
+                for (int i = 0; i < datagramBefore.size(); i++) {
+                    if (!datagramBefore.get(i).equals(datagramAfter.get(i))) {
+                        result = false;
+                        break;
+                    }
+                }
+            } else {
+                result = false;
+                continue;
+            }
+            Files.delete(Paths.get(BEFORE));
+            Files.delete(Paths.get(AFTER));
+        }
+        return result;
     }
 
     /**
@@ -215,6 +259,24 @@ public class DataGeneratorTest {
     @Test
     public void testCodepointLength() throws Exception {
         DataGeneratorTest.violationDetect(INPUT_SCHEMA_CONTAINS_CODEPOINT_LENGTH);
+    }
+
+    /**
+     * Test if the '--seed' option allows us to generate the same random value.
+     * @throws Exception if error occurs during the executing and comparison process.
+     */
+    @Test
+    public void testSeedOption() throws Exception {
+        assertTrue(generateAndCompare(true));
+    }
+
+    /**
+     * Test if the generated data is randomized when there is no '--seed' option provided.
+     * @throws Exception if error occurs during the executing and comparison process.
+     */
+    @Test
+    public void testWithoutSeed() throws Exception {
+        assertTrue(!generateAndCompare(false));
     }
 
     /**

--- a/tst/com/amazon/ion/benchmark/DataGeneratorTest.java
+++ b/tst/com/amazon/ion/benchmark/DataGeneratorTest.java
@@ -39,7 +39,7 @@ import java.nio.file.Paths;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-
+import static org.junit.Assert.assertFalse;
 
 public class DataGeneratorTest {
     private static String outputFile = null;
@@ -81,8 +81,6 @@ public class DataGeneratorTest {
     private final static String SERIALIZED_SIZE = "Serialized size";
     private final static String SPEED = "speed";
     private final static File[] TEST_ISL_FILES = new File("./tst/com/amazon/ion/datagenerator/").listFiles();
-    private final static String BEFORE = "testSeed0.ion";
-    private final static String AFTER = "testSeed1.ion";
 
     /**
      * Construct IonReader for current output file in order to finish the following test process.
@@ -141,18 +139,22 @@ public class DataGeneratorTest {
      */
     public Boolean generateAndCompare(Boolean seedOption) throws Exception {
         Boolean result = true;
+        String outputBefore = "testSeed0.ion";
+        String outputAfter = "testSeed1.ion";
         for (File testFile : TEST_ISL_FILES) {
             String testFilePath = testFile.getPath();
             for (int i = 0; i < 2; i++) {
                 String outputFile = "testSeed" + i + ".ion";
-                Map <String, Object> optionsMap = Main.parseArguments("generate", "--data-size", "5000", "--format", "ion_text", "--input-ion-schema", testFilePath, outputFile);
+                Map<String, Object> optionsMap;
                 if (seedOption == true) {
                     optionsMap = Main.parseArguments("generate", "--data-size", "5000", "--seed", "200", "--format", "ion_text", "--input-ion-schema", testFilePath, outputFile);
+                } else {
+                    optionsMap = Main.parseArguments("generate", "--data-size", "5000", "--format", "ion_text", "--input-ion-schema", testFilePath, outputFile);
                 }
                 GeneratorOptions.executeGenerator(optionsMap);
             }
-            IonDatagram datagramBefore = LOADER.load(new FileInputStream(BEFORE));
-            IonDatagram datagramAfter = LOADER.load(new FileInputStream(AFTER));
+            IonDatagram datagramBefore = LOADER.load(new FileInputStream(outputBefore));
+            IonDatagram datagramAfter = LOADER.load(new FileInputStream(outputAfter));
             if (datagramBefore.size() == datagramAfter.size()) {
                 for (int i = 0; i < datagramBefore.size(); i++) {
                     if (!datagramBefore.get(i).equals(datagramAfter.get(i))) {
@@ -164,8 +166,8 @@ public class DataGeneratorTest {
                 result = false;
                 continue;
             }
-            Files.delete(Paths.get(BEFORE));
-            Files.delete(Paths.get(AFTER));
+            Files.delete(Paths.get(outputBefore));
+            Files.delete(Paths.get(outputAfter));
         }
         return result;
     }
@@ -276,7 +278,7 @@ public class DataGeneratorTest {
      */
     @Test
     public void testWithoutSeed() throws Exception {
-        assertTrue(!generateAndCompare(false));
+        assertFalse(generateAndCompare(false));
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This PR adds an option `--seed` which allows users to specify the seed value when generating random ion data. If the provided seed value and the schema file are the same as the last execution, the same randomized ion data will be generated.

**GeneratorOptions.java**
Add a static field `randomSeed` to the class `GeneratorOptions`. This field will be overwrote in the step of processing the `--seed` option. If the seed value provided, the random instance will be crated with the specified seed value and be used in the following data generation process. Otherwise, the random instance will be created with a random seed value. 

**Main.java**
Add an option `--seed` which allow users to specify the seed value. When they re-run the command with the same seed value and the same input ion schema, the same randomized ion data will be generated.

**Test**
- Add unit test to test whether the generated randomized data is as same as the last execution when specifying the seed value.
- Add unit test to test if the regenerated data is randomized when there is no seed value provided. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
