### PR TITLE
Update the option '--format' as optional.

### DIFF
--- a/src/com/amazon/ion/benchmark/Main.java
+++ b/src/com/amazon/ion/benchmark/Main.java
@@ -42,7 +42,7 @@ public class Main {
             + "[--ion-use-lob-chunks <bool>]... [--ion-use-big-decimals <bool>]... [--ion-reader-buffer-size <int>]... "
             + "[--json-use-big-decimals <bool>]... <input_file>\n"
         
-        + "  ion-java-benchmark generate [--seed <seed_value>] (--data-size <data_size>) (--format <type>) (--input-ion-schema <file_path>) <output_file>\n"
+        + "  ion-java-benchmark generate [--seed <seed_value>] [--format <type>] (--data-size <data_size>) (--input-ion-schema <file_path>) <output_file>\n"
 
         + "  ion-java-benchmark compare (--benchmark-result-previous <file_path>) (--benchmark-result-new <file_path>) <output_file>\n"
 


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
This PR updates the option` --format` as optional. When the option `--format` is not provided, the default format of the generated data is `ion_binary`. The value of this option is one of `[ion_text | ion_binary]`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
