### PR TITLE
Add option --auto-flush to enable benchmarking of ion-java writer with auto-flush configured.

### DIFF
--- a/src/com/amazon/ion/benchmark/Constants.java
+++ b/src/com/amazon/ion/benchmark/Constants.java
@@ -25,6 +25,7 @@ class Constants {
     static final String JSON_USE_BIG_DECIMALS_NAME = "g";
     static final String AUTO_VALUE = "auto";
     static final String NONE_VALUE = "none";
+    static final String AUTO_FLUSH_ENABLED = "m";
 
     private Constants() {
         // Do not instantiate.

--- a/src/com/amazon/ion/benchmark/IonUtilities.java
+++ b/src/com/amazon/ion/benchmark/IonUtilities.java
@@ -168,6 +168,11 @@ class IonUtilities {
         } else {
             builder.withFloatBinary32Disabled();
         }
+        if(options.autoFlush) {
+            builder.withAutoFlushEnabled();
+        } else {
+            builder.withAutoFlushDisabled();
+        }
         if (options instanceof WriteOptionsCombination) {
             // When this method is used by the read benchmark for converting the input file, 'options' will be a
             // ReadOptionsCombination, which does not have the 'ionWriterUserBufferSize' value, because this value

--- a/src/com/amazon/ion/benchmark/Main.java
+++ b/src/com/amazon/ion/benchmark/Main.java
@@ -201,7 +201,7 @@ public class Main {
             + "[default: auto]\n"
 
         + "  -m --auto-flush <bool>                 If this option is enabled, then the flush operation will be executed "
-            + "automatically when the size of the value is overflow "
+            + "automatically when the size of the value exceeds the writer's block size. This option may be specified multiple times to compare different values."
             + "[default: false]\n"
 
         // 'read' options:

--- a/src/com/amazon/ion/benchmark/Main.java
+++ b/src/com/amazon/ion/benchmark/Main.java
@@ -30,7 +30,7 @@ public class Main {
             + "[--results-file <file>] [--io-type <type>]... [--io-buffer-size <int>]... [--format <type>]... "
             + "[--api <api>]... [--ion-imports-for-input <file>] [--ion-imports-for-benchmark <file>]... "
             + "[--ion-flush-period <int>]... [--ion-length-preallocation <int>]... [--ion-float-width <int>]... "
-            + "[--ion-use-symbol-tokens <bool>]... [--ion-writer-block-size <int>]... "
+            + "[--ion-use-symbol-tokens <bool>]... [--ion-writer-block-size <int>]... [--auto-flush <bool>]..."
             + "[--json-use-big-decimals <bool>]... <input_file>\n"
 
         + "  ion-java-benchmark read [--profile] [--limit <int>] [--mode <mode>] [--time-unit <unit>] "
@@ -199,6 +199,10 @@ public class Main {
             + "buffer data, or 'auto', which uses the default value provided by the Ion writer builder. May be "
             + "specified multiple times to compare different values. Ignored unless the format is ion_binary. "
             + "[default: auto]\n"
+
+        + "  -m --auto-flush <bool>                 If this option is enabled, then the flush operation will be executed "
+            + "automatically when the size of the value is overflow "
+            + "[default: false]\n"
 
         // 'read' options:
 

--- a/src/com/amazon/ion/benchmark/OptionsCombinationBase.java
+++ b/src/com/amazon/ion/benchmark/OptionsCombinationBase.java
@@ -19,9 +19,10 @@ import java.io.OutputStream;
 import java.nio.file.Path;
 import java.util.function.Function;
 
+import static com.amazon.ion.benchmark.Constants.API_NAME;
+import static com.amazon.ion.benchmark.Constants.AUTO_FLUSH_ENABLED;
 import static com.amazon.ion.benchmark.Constants.FLUSH_PERIOD_NAME;
 import static com.amazon.ion.benchmark.Constants.FORMAT_NAME;
-import static com.amazon.ion.benchmark.Constants.API_NAME;
 import static com.amazon.ion.benchmark.Constants.ION_FLOAT_WIDTH_NAME;
 import static com.amazon.ion.benchmark.Constants.ION_IMPORTS_FOR_BENCHMARK_NAME;
 import static com.amazon.ion.benchmark.Constants.ION_IMPORTS_FOR_INPUT_NAME;
@@ -49,6 +50,7 @@ abstract class OptionsCombinationBase {
     final boolean useSymbolTokens;
     final int limit;
     final boolean jsonUseBigDecimals;
+    final boolean autoFlush;
 
     /**
      * Retrieves and translates a value from the struct, if the field is present and is not the 'auto' value. Otherwise,
@@ -89,6 +91,7 @@ abstract class OptionsCombinationBase {
         useSymbolTokens = getOrDefault(optionsCombinationStruct, ION_USE_SYMBOL_TOKENS_NAME, val -> ((IonBool) val).booleanValue(), false);
         limit = getOrDefault(optionsCombinationStruct, LIMIT_NAME, val -> ((IonInt) val).intValue(), Integer.MAX_VALUE);
         jsonUseBigDecimals = getOrDefault(optionsCombinationStruct, JSON_USE_BIG_DECIMALS_NAME, val -> ((IonBool) val).booleanValue(), true);
+        autoFlush = getOrDefault(optionsCombinationStruct, AUTO_FLUSH_ENABLED, val -> ((IonBool) val).booleanValue(), false);
     }
 
     /**

--- a/src/com/amazon/ion/benchmark/OptionsMatrixBase.java
+++ b/src/com/amazon/ion/benchmark/OptionsMatrixBase.java
@@ -23,9 +23,10 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
+import static com.amazon.ion.benchmark.Constants.API_NAME;
+import static com.amazon.ion.benchmark.Constants.AUTO_FLUSH_ENABLED;
 import static com.amazon.ion.benchmark.Constants.FLUSH_PERIOD_NAME;
 import static com.amazon.ion.benchmark.Constants.FORMAT_NAME;
-import static com.amazon.ion.benchmark.Constants.API_NAME;
 import static com.amazon.ion.benchmark.Constants.ION_FLOAT_WIDTH_NAME;
 import static com.amazon.ion.benchmark.Constants.ION_IMPORTS_FOR_BENCHMARK_NAME;
 import static com.amazon.ion.benchmark.Constants.ION_IMPORTS_FOR_INPUT_NAME;
@@ -402,6 +403,15 @@ abstract class OptionsMatrixBase {
             optionsCombinationStructs,
             () -> ION_SYSTEM.newBool(true),
             OPTION_ONLY_APPLIES_TO_JSON
+        );
+        parseAndCombine(
+            optionsMatrix.get("--auto-flush"),
+            AUTO_FLUSH_ENABLED,
+            OptionsMatrixBase::getTrueOrNull,
+            ION_SYSTEM::newBool,
+            optionsCombinationStructs,
+            () -> ION_SYSTEM.newBool(false),
+            OPTION_ONLY_APPLIES_TO_ION_STREAMING
         );
         parseCommandSpecificOptions(optionsMatrix, optionsCombinationStructs);
         serializedOptionsCombinations = serializeOptionsCombinations(optionsCombinationStructs);

--- a/tst/com/amazon/ion/benchmark/OptionsTest.java
+++ b/tst/com/amazon/ion/benchmark/OptionsTest.java
@@ -353,6 +353,7 @@ public class OptionsTest {
         extends ExpectedOptionsCombinationBase<ExpectedWriteOptionsCombination, WriteOptionsCombination> {
 
         Integer ionWriterBlockSize = null;
+        Boolean autoFlush = null;
 
         static ExpectedWriteOptionsCombination defaultOptions() {
             return new ExpectedWriteOptionsCombination();
@@ -360,6 +361,11 @@ public class OptionsTest {
 
         final ExpectedWriteOptionsCombination ionWriterBlockSize(Integer ionWriterBlockSize) {
             this.ionWriterBlockSize = ionWriterBlockSize;
+            return this;
+        }
+
+        final ExpectedWriteOptionsCombination autoFlush(Boolean autoFlush) {
+            this.autoFlush = autoFlush;
             return this;
         }
 
@@ -1220,6 +1226,33 @@ public class OptionsTest {
 
             assertWriteTaskExecutesCorrectly("binaryStructs.10n", optionsCombination, Format.ION_BINARY, IoType.FILE);
             assertWriteTaskExecutesCorrectly("textStructs.ion", optionsCombination, Format.ION_BINARY, IoType.FILE);
+        }
+        assertTrue(expectedCombinations.isEmpty());
+    }
+
+    @Test
+    public void autoFlush() throws Exception {
+        List<WriteOptionsCombination> optionsCombinations = parseOptionsCombinations(
+                "write",
+                "--auto-flush",
+                "true",
+                "--auto-flush",
+                "false",
+                "--io-type",
+                "buffer",
+                "binaryStructs.10n"
+        );
+        assertEquals(2, optionsCombinations.size());
+        List<ExpectedWriteOptionsCombination> expectedCombinations = new ArrayList<>(2);
+
+        expectedCombinations.add(ExpectedWriteOptionsCombination.defaultOptions().autoFlush(true));
+        expectedCombinations.add(ExpectedWriteOptionsCombination.defaultOptions().autoFlush(false));
+
+        for (WriteOptionsCombination optionsCombination : optionsCombinations) {
+            expectedCombinations.removeIf(candidate -> nullSafeEquals(candidate.autoFlush, optionsCombination.autoFlush));
+
+            assertWriteTaskExecutesCorrectly("binaryStructs.10n", optionsCombination, Format.ION_BINARY, IoType.BUFFER);
+            assertWriteTaskExecutesCorrectly("textStructs.ion", optionsCombination, Format.ION_BINARY, IoType.BUFFER);
         }
         assertTrue(expectedCombinations.isEmpty());
     }


### PR DESCRIPTION
### Issue #, if available:
N/A

### Description of changes:
This PR adds an option to benchmark the ion-java binary writing with/without auto-flush enabled. 

_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
