### PR TITLE
Adds support for Ion 1.1 delimited containers and inline symbols.

### DIFF
--- a/src/com/amazon/ion/benchmark/Constants.java
+++ b/src/com/amazon/ion/benchmark/Constants.java
@@ -22,6 +22,8 @@ class Constants {
     static final String ION_READER_BUFFER_SIZE_NAME = "Z";
     static final String PATHS_NAME = "s";
     static final String ION_WRITER_BLOCK_SIZE_NAME = "b";
+    static final String ION_INLINE_SYMBOLS_NAME = "N";
+    static final String ION_DELIMITED_CONTAINERS_NAME = "C";
     static final String ION_MINOR_VERSION_NAME = "V";
     static final String JSON_USE_BIG_DECIMALS_NAME = "g";
     static final String AUTO_VALUE = "auto";

--- a/src/com/amazon/ion/benchmark/Format.java
+++ b/src/com/amazon/ion/benchmark/Format.java
@@ -19,6 +19,8 @@ enum Format {
             switch (sourceFormat) {
                 case ION_BINARY:
                     boolean optionsRequireRewrite = options.flushPeriod != null
+                        || options.ionDelimitedContainers != null
+                        || options.ionInlineSymbols != null
                         || options.preallocation != null
                         || options.floatWidth != null
                         || (options.ionMinorVersion != null && !IonUtilities.minorVersionsEqual(options.ionMinorVersion, input.toFile()))

--- a/src/com/amazon/ion/benchmark/Gradient.java
+++ b/src/com/amazon/ion/benchmark/Gradient.java
@@ -1,0 +1,12 @@
+package com.amazon.ion.benchmark;
+
+/**
+ * Represents amounts from "none" to "all".
+ */
+public enum Gradient {
+    ALL,
+    NONE
+    // TODO options could be added to allow more manual configuration (e.g. via pointing to a file), or to allow
+    //  preservation of characteristics from the input file. If more specific options are needed, a different enum
+    //  more suited to the purpose may need to be used instead.
+}

--- a/src/com/amazon/ion/benchmark/IonUtilities.java
+++ b/src/com/amazon/ion/benchmark/IonUtilities.java
@@ -11,6 +11,8 @@ import com.amazon.ion.SpanProvider;
 import com.amazon.ion.SymbolTable;
 import com.amazon.ion.impl._Private_IonConstants;
 import com.amazon.ion.impl._Private_IonSystem;
+import com.amazon.ion.impl.bin.DelimitedContainerStrategy;
+import com.amazon.ion.impl.bin.SymbolInliningStrategy;
 import com.amazon.ion.impl.bin._Private_IonManagedBinaryWriterBuilder;
 import com.amazon.ion.system.IonBinaryWriterBuilder_1_1;
 import com.amazon.ion.system.IonReaderBuilder;
@@ -234,6 +236,8 @@ class IonUtilities {
     private static IonWriterSupplier newBinaryWriterSupplier_1_1(OptionsCombinationBase options) throws IOException {
         IonBinaryWriterBuilder_1_1 builder = IonEncodingVersion.ION_1_1.binaryWriterBuilder();
         builder.withImports(parseImportsFromFile(options.importsForBenchmarkFile));
+        builder.withSymbolInliningStrategy(options.ionInlineSymbols == Gradient.ALL ? SymbolInliningStrategy.ALWAYS_INLINE : SymbolInliningStrategy.NEVER_INLINE);
+        builder.withDelimitedContainerStrategy(options.ionDelimitedContainers == Gradient.ALL ? DelimitedContainerStrategy.ALWAYS_DELIMITED : DelimitedContainerStrategy.ALWAYS_PREFIXED);
         if (options instanceof WriteOptionsCombination) {
             // When this method is used by the read benchmark for converting the input file, 'options' will be a
             // ReadOptionsCombination, which does not have the 'ionWriterUserBufferSize' value, because this value
@@ -415,6 +419,7 @@ class IonUtilities {
                 options.importsForInputFile == null &&
                 options.importsForBenchmarkFile == null &&
                 options.format == Format.ION_BINARY &&
+                options.ionMinorVersion != 1 && // TODO remove once support for writing system values via the Ion 1.1 writer is added.
                 IonUtilities.minorVersionsEqual(options.ionMinorVersion, input.toFile())
             ) {
                 // Use system-level reader to preserve the same symbol tables from the input.

--- a/src/com/amazon/ion/benchmark/Main.java
+++ b/src/com/amazon/ion/benchmark/Main.java
@@ -31,7 +31,8 @@ public class Main {
             + "[--api <api>]... [--ion-imports-for-input <file>] [--ion-imports-for-benchmark <file>]... "
             + "[--ion-flush-period <int>]... [--ion-length-preallocation <int>]... [--ion-float-width <int>]... "
             + "[--ion-use-symbol-tokens <bool>]... [--ion-writer-block-size <int>]... [--auto-flush <bool>]... "
-            + "[--ion-minor-version <int>]... [--json-use-big-decimals <bool>]... <input_file>\n"
+            + "[--ion-minor-version <int>]... [--ion-inline-symbols <option>]... [--ion-delimited-containers <option>]... "
+            + "[--json-use-big-decimals <bool>]... <input_file>\n"
 
         + "  ion-java-benchmark read [--profile] [--limit <int>] [--mode <mode>] [--time-unit <unit>] "
             + "[--warmups <int>] [--iterations <int>] [--forks <int>] [--results-format <type>] "
@@ -40,7 +41,8 @@ public class Main {
             + "[--ion-flush-period <int>]... [--ion-length-preallocation <int>]... [--ion-float-width <int>]... "
             + "[--ion-use-symbol-tokens <bool>]... [--paths <file>] [--ion-reader <type>]... "
             + "[--ion-use-lob-chunks <bool>]... [--ion-use-big-decimals <bool>]... [--ion-reader-buffer-size <int>]... "
-            + "[--ion-minor-version <int>]... [--json-use-big-decimals <bool>]... <input_file>\n"
+            + "[--ion-minor-version <int>]... [--ion-inline-symbols <option>]... [--ion-delimited-containers <option>]... "
+            + "[--json-use-big-decimals <bool>]... <input_file>\n"
 
         + "  ion-java-benchmark run-suite (--test-ion-data <file_path>) (--benchmark-options-combinations <file_path>) <output_file>\n"
 
@@ -188,6 +190,20 @@ public class Main {
             + "than Strings. Either 'true' or 'false'. Ignored unless --format is ion_text or ion_binary and --ion-api "
             + "is streaming. Must be 'true' when the streaming APIs are used with Ion streams that contain symbols "
             + "with unknown text. May be specified twice to compare both settings. [default: false]\n"
+
+        + "  -N --ion-inline-symbols <option>       Controls whether an Ion 1.1 binary writer writes symbol tokens "
+            + "inline, rather than using symbol IDs. Ignored unless --ion-minor-version is greater than 0 and --format "
+            + "is ion_binary. Selected from the set (all | none | auto). For write benchmarks, 'auto' causes 'none' "
+            + "to be used; for read benchmarks, 'auto' will not force rewrite of the input data before reading, but "
+            + "if a different option triggers rewrite then 'none' will be used. This option may be specified multiple "
+            + "times to compare different values. [default: auto]\n"
+
+        + "  -C --ion-delimited-containers <option>   Controls whether an Ion 1.1 binary writer writes containers using "
+            + "the delimited encoding, rather than using length-prefixing. Ignored unless --ion-minor-version is "
+            + "greater than 0 and --format is ion_binary. Selected from the set (all | none | auto). For write "
+            + "benchmarks, 'auto' causes 'none' to be used; for read benchmarks, 'auto' will not force rewrite of "
+            + "the input data before reading, but if a different option triggers rewrite then 'none' will be used. "
+            + "This option may be specified multiple times to compare different values. [default: auto]\n"
 
         + "  -g --json-use-big-decimals <bool>      When reading and/or writing JSON non-integer numeric values, use "
             + "BigDecimal in order to preserve precision. When false, `double` will be used and precision may be lost. "

--- a/src/com/amazon/ion/benchmark/OptionsCombinationBase.java
+++ b/src/com/amazon/ion/benchmark/OptionsCombinationBase.java
@@ -23,9 +23,11 @@ import static com.amazon.ion.benchmark.Constants.API_NAME;
 import static com.amazon.ion.benchmark.Constants.AUTO_FLUSH_ENABLED;
 import static com.amazon.ion.benchmark.Constants.FLUSH_PERIOD_NAME;
 import static com.amazon.ion.benchmark.Constants.FORMAT_NAME;
+import static com.amazon.ion.benchmark.Constants.ION_DELIMITED_CONTAINERS_NAME;
 import static com.amazon.ion.benchmark.Constants.ION_FLOAT_WIDTH_NAME;
 import static com.amazon.ion.benchmark.Constants.ION_IMPORTS_FOR_BENCHMARK_NAME;
 import static com.amazon.ion.benchmark.Constants.ION_IMPORTS_FOR_INPUT_NAME;
+import static com.amazon.ion.benchmark.Constants.ION_INLINE_SYMBOLS_NAME;
 import static com.amazon.ion.benchmark.Constants.ION_MINOR_VERSION_NAME;
 import static com.amazon.ion.benchmark.Constants.ION_USE_SYMBOL_TOKENS_NAME;
 import static com.amazon.ion.benchmark.Constants.IO_BUFFER_SIZE_NAME;
@@ -53,6 +55,8 @@ abstract class OptionsCombinationBase {
     final boolean jsonUseBigDecimals;
     final boolean autoFlush;
     final Integer ionMinorVersion;
+    final Gradient ionInlineSymbols;
+    final Gradient ionDelimitedContainers;
 
     /**
      * Retrieves and translates a value from the struct, if the field is present and is not the 'auto' value. Otherwise,
@@ -95,6 +99,8 @@ abstract class OptionsCombinationBase {
         jsonUseBigDecimals = getOrDefault(optionsCombinationStruct, JSON_USE_BIG_DECIMALS_NAME, val -> ((IonBool) val).booleanValue(), true);
         autoFlush = getOrDefault(optionsCombinationStruct, AUTO_FLUSH_ENABLED, val -> ((IonBool) val).booleanValue(), false);
         ionMinorVersion = getOrDefault(optionsCombinationStruct, ION_MINOR_VERSION_NAME, val -> ((IonInt) val).intValue(), 0);
+        ionInlineSymbols = getOrDefault(optionsCombinationStruct, ION_INLINE_SYMBOLS_NAME, val -> Gradient.valueOf(((IonText) val).stringValue()), null);
+        ionDelimitedContainers = getOrDefault(optionsCombinationStruct, ION_DELIMITED_CONTAINERS_NAME, val -> Gradient.valueOf(((IonText) val).stringValue()), null);
     }
 
     /**

--- a/src/com/amazon/ion/benchmark/OptionsMatrixBase.java
+++ b/src/com/amazon/ion/benchmark/OptionsMatrixBase.java
@@ -1,5 +1,6 @@
 package com.amazon.ion.benchmark;
 
+import com.amazon.ion.IonInt;
 import com.amazon.ion.IonStruct;
 import com.amazon.ion.IonText;
 import com.amazon.ion.IonValue;
@@ -14,6 +15,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import java.io.File;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -27,9 +29,11 @@ import static com.amazon.ion.benchmark.Constants.API_NAME;
 import static com.amazon.ion.benchmark.Constants.AUTO_FLUSH_ENABLED;
 import static com.amazon.ion.benchmark.Constants.FLUSH_PERIOD_NAME;
 import static com.amazon.ion.benchmark.Constants.FORMAT_NAME;
+import static com.amazon.ion.benchmark.Constants.ION_DELIMITED_CONTAINERS_NAME;
 import static com.amazon.ion.benchmark.Constants.ION_FLOAT_WIDTH_NAME;
 import static com.amazon.ion.benchmark.Constants.ION_IMPORTS_FOR_BENCHMARK_NAME;
 import static com.amazon.ion.benchmark.Constants.ION_IMPORTS_FOR_INPUT_NAME;
+import static com.amazon.ion.benchmark.Constants.ION_INLINE_SYMBOLS_NAME;
 import static com.amazon.ion.benchmark.Constants.ION_MINOR_VERSION_NAME;
 import static com.amazon.ion.benchmark.Constants.ION_SYSTEM;
 import static com.amazon.ion.benchmark.Constants.ION_USE_SYMBOL_TOKENS_NAME;
@@ -52,12 +56,26 @@ abstract class OptionsMatrixBase {
     static final Predicate<IonStruct> OPTION_ONLY_APPLIES_TO_ION_BINARY = s -> {
         return Format.ION_BINARY.name().equals(getStringValue(s, FORMAT_NAME));
     };
+    static final Predicate<IonStruct> OPTION_ONLY_APPLIES_TO_ION_1_1_PLUS = s -> {
+        return getIntegerValue(s, ION_MINOR_VERSION_NAME, 0) > 0;
+    };
     static final Predicate<IonStruct> OPTION_ONLY_APPLIES_TO_ION_STREAMING = s -> {
         return OPTION_ONLY_APPLIES_TO_ION.test(s) && API.STREAMING.name().equals(getStringValue(s, API_NAME));
     };
     static final Predicate<IonStruct> OPTION_ONLY_APPLIES_TO_JSON = s -> {
         return Format.JSON.name().equals(getStringValue(s, FORMAT_NAME));
     };
+
+    static Predicate<IonStruct> allOf(List<Predicate<IonStruct>> predicates) {
+        return s -> {
+            for (Predicate<IonStruct> predicate : predicates) {
+                if (!predicate.test(s)) {
+                    return false;
+                }
+            }
+            return true;
+        };
+    }
 
     private final String inputFile;
     private final String[] serializedOptionsCombinations;
@@ -77,6 +95,21 @@ abstract class OptionsMatrixBase {
             valueString = ((IonText) value).stringValue();
         }
         return valueString;
+    }
+
+    /**
+     * Retrieves the Integer value for the requested option, or null if the option is not present.
+     * @param optionsCombination an options combination struct.
+     * @param optionShortName the abbreviated name for the option.
+     * @return an Integer, or null if the option did not exist.
+     */
+    static int getIntegerValue(IonStruct optionsCombination, String optionShortName, int defaultValue) {
+        IonValue value = optionsCombination.get(optionShortName);
+        int valueInteger = defaultValue;
+        if (value != null) {
+            valueInteger = ((IonInt) value).intValue();
+        }
+        return valueInteger;
     }
 
     /**
@@ -233,6 +266,17 @@ abstract class OptionsMatrixBase {
             return null;
         }
         return Integer.parseInt(intOrAuto);
+    }
+
+    /**
+     * @param gradientOrAuto a String representation of an Gradient, or the String 'auto', or null.
+     * @return null if the input is null or is 'auto'; otherwise, the Gradient parsed from the input.
+     */
+    static Gradient getGradientOrAuto(String gradientOrAuto) {
+        if (gradientOrAuto == null || gradientOrAuto.equals(Constants.AUTO_VALUE)) {
+            return null;
+        }
+        return Gradient.valueOf(gradientOrAuto.toUpperCase());
     }
 
     /**
@@ -422,6 +466,24 @@ abstract class OptionsMatrixBase {
             optionsCombinationStructs,
             () -> ION_SYSTEM.newBool(false),
             OPTION_ONLY_APPLIES_TO_ION_STREAMING
+        );
+        parseAndCombine(
+            optionsMatrix.get("--ion-inline-symbols"),
+            ION_INLINE_SYMBOLS_NAME,
+            OptionsMatrixBase::getGradientOrAuto,
+            g -> ION_SYSTEM.newSymbol(g.name()),
+            optionsCombinationStructs,
+            () -> ION_SYSTEM.newSymbol(Constants.AUTO_VALUE),
+            allOf(Arrays.asList(OPTION_ONLY_APPLIES_TO_ION_1_1_PLUS, OPTION_ONLY_APPLIES_TO_ION_BINARY))
+        );
+        parseAndCombine(
+            optionsMatrix.get("--ion-delimited-containers"),
+            ION_DELIMITED_CONTAINERS_NAME,
+            OptionsMatrixBase::getGradientOrAuto,
+            g -> ION_SYSTEM.newSymbol(g.name()),
+            optionsCombinationStructs,
+            () -> ION_SYSTEM.newSymbol(Constants.AUTO_VALUE),
+            allOf(Arrays.asList(OPTION_ONLY_APPLIES_TO_ION_1_1_PLUS, OPTION_ONLY_APPLIES_TO_ION_BINARY))
         );
         parseCommandSpecificOptions(optionsMatrix, optionsCombinationStructs);
         serializedOptionsCombinations = serializeOptionsCombinations(optionsCombinationStructs);

--- a/tst/com/amazon/ion/benchmark/OptionsTest.java
+++ b/tst/com/amazon/ion/benchmark/OptionsTest.java
@@ -218,6 +218,8 @@ public class OptionsTest {
         Integer floatWidth = null;
         boolean jsonUseBigDecimals = true;
         Integer ionMinorVersion = 0;
+        Gradient ionInlineSymbols = null;
+        Gradient ionDelimitedContainers = null;
 
         final T preallocation(Integer preallocation) {
             this.preallocation = preallocation;
@@ -284,6 +286,16 @@ public class OptionsTest {
             return (T) this;
         }
 
+        final T ionInlineSymbols(Gradient ionInlineSymbols) {
+            this.ionInlineSymbols = ionInlineSymbols;
+            return (T) this;
+        }
+
+        final T ionDelimitedContainers(Gradient ionDelimitedContainers) {
+            this.ionDelimitedContainers = ionDelimitedContainers;
+            return (T) this;
+        }
+
         void assertOptionsEqual(U that) {
             assertEquals(flushPeriod, that.flushPeriod);
             assertEquals(api, that.api);
@@ -297,6 +309,8 @@ public class OptionsTest {
             assertEquals(floatWidth, that.floatWidth);
             assertEquals(jsonUseBigDecimals, that.jsonUseBigDecimals);
             assertEquals(ionMinorVersion, that.ionMinorVersion);
+            assertEquals(ionInlineSymbols, that.ionInlineSymbols);
+            assertEquals(ionDelimitedContainers, that.ionDelimitedContainers);
         }
     }
 
@@ -2240,5 +2254,115 @@ public class OptionsTest {
     public void readAllTypes10And11() throws Exception {
         readAllTypes10And11("binaryAllTypes.10n", 0);
         readAllTypes10And11("binaryAllTypes11.10n", 1);
+    }
+
+    private void readIonWithInlineSymbolsAndDelimitedContainers(String file, int fileMinorVersion) throws Exception {
+        List<ReadOptionsCombination> optionsCombinations = parseOptionsCombinations(
+            "read",
+            "--format",
+            "ion_binary",
+            "--ion-minor-version",
+            "0",
+            "--ion-minor-version",
+            "1",
+            "--ion-inline-symbols",
+            "all",
+            "--ion-inline-symbols",
+            "none",
+            "--ion-inline-symbols",
+            "auto",
+            "--ion-delimited-containers",
+            "all",
+            "--ion-delimited-containers",
+            "none",
+            "--ion-delimited-containers",
+            "auto",
+            file
+        );
+        assertEquals(10, optionsCombinations.size());
+        List<ExpectedReadOptionsCombination> expectedCombinations = new ArrayList<>(10);
+
+        expectedCombinations.add(ExpectedReadOptionsCombination.defaultOptions().format(Format.ION_BINARY).ionMinorVersion(0));
+        expectedCombinations.add(ExpectedReadOptionsCombination.defaultOptions().format(Format.ION_BINARY).ionMinorVersion(1));
+        expectedCombinations.add(ExpectedReadOptionsCombination.defaultOptions().format(Format.ION_BINARY).ionMinorVersion(1).ionInlineSymbols(Gradient.NONE).ionDelimitedContainers(Gradient.NONE));
+        expectedCombinations.add(ExpectedReadOptionsCombination.defaultOptions().format(Format.ION_BINARY).ionMinorVersion(1).ionInlineSymbols(Gradient.ALL).ionDelimitedContainers(Gradient.NONE));
+        expectedCombinations.add(ExpectedReadOptionsCombination.defaultOptions().format(Format.ION_BINARY).ionMinorVersion(1).ionInlineSymbols(Gradient.NONE).ionDelimitedContainers(Gradient.ALL));
+        expectedCombinations.add(ExpectedReadOptionsCombination.defaultOptions().format(Format.ION_BINARY).ionMinorVersion(1).ionInlineSymbols(Gradient.ALL).ionDelimitedContainers(Gradient.ALL));
+        expectedCombinations.add(ExpectedReadOptionsCombination.defaultOptions().format(Format.ION_BINARY).ionMinorVersion(1).ionInlineSymbols(Gradient.ALL));
+        expectedCombinations.add(ExpectedReadOptionsCombination.defaultOptions().format(Format.ION_BINARY).ionMinorVersion(1).ionInlineSymbols(Gradient.NONE));
+        expectedCombinations.add(ExpectedReadOptionsCombination.defaultOptions().format(Format.ION_BINARY).ionMinorVersion(1).ionDelimitedContainers(Gradient.ALL));
+        expectedCombinations.add(ExpectedReadOptionsCombination.defaultOptions().format(Format.ION_BINARY).ionMinorVersion(1).ionDelimitedContainers(Gradient.NONE));
+
+        for (ReadOptionsCombination optionsCombination : optionsCombinations) {
+            expectedCombinations.removeIf(candidate -> nullSafeEquals(candidate.ionMinorVersion, 0) ||
+                (nullSafeEquals(candidate.ionInlineSymbols, optionsCombination.ionInlineSymbols)
+                    && nullSafeEquals(candidate.ionDelimitedContainers, optionsCombination.ionDelimitedContainers)));
+
+            boolean isConversionRequired = optionsCombination.ionMinorVersion != fileMinorVersion ||
+                optionsCombination.ionInlineSymbols != null ||
+                optionsCombination.ionDelimitedContainers != null;
+            assertReadTaskExecutesCorrectly(file, optionsCombination, optionsCombination.format, isConversionRequired);
+        }
+        assertTrue(expectedCombinations.isEmpty());
+    }
+
+    @Test
+    public void readIonWithInlineSymbolsAndDelimitedContainers() throws Exception {
+        readIonWithInlineSymbolsAndDelimitedContainers("binaryAllTypes.10n", 0);
+        readIonWithInlineSymbolsAndDelimitedContainers("binaryAllTypes11.10n", 1);
+    }
+
+    private void writeIonWithInlineSymbolsAndDelimitedContainers(String file) throws Exception {
+        List<WriteOptionsCombination> optionsCombinations = parseOptionsCombinations(
+            "write",
+            "--format",
+            "ion_binary",
+            "--ion-minor-version",
+            "0",
+            "--ion-minor-version",
+            "1",
+            "--ion-inline-symbols",
+            "all",
+            "--ion-inline-symbols",
+            "none",
+            "--ion-inline-symbols",
+            "auto",
+            "--ion-delimited-containers",
+            "all",
+            "--ion-delimited-containers",
+            "none",
+            "--ion-delimited-containers",
+            "auto",
+            file
+        );
+
+        assertEquals(10, optionsCombinations.size());
+        List<ExpectedWriteOptionsCombination> expectedCombinations = new ArrayList<>(10);
+
+        expectedCombinations.add(ExpectedWriteOptionsCombination.defaultOptions().format(Format.ION_BINARY).ionMinorVersion(0));
+        expectedCombinations.add(ExpectedWriteOptionsCombination.defaultOptions().format(Format.ION_BINARY).ionMinorVersion(1));
+        expectedCombinations.add(ExpectedWriteOptionsCombination.defaultOptions().format(Format.ION_BINARY).ionMinorVersion(1).ionInlineSymbols(Gradient.NONE).ionDelimitedContainers(Gradient.NONE));
+        expectedCombinations.add(ExpectedWriteOptionsCombination.defaultOptions().format(Format.ION_BINARY).ionMinorVersion(1).ionInlineSymbols(Gradient.ALL).ionDelimitedContainers(Gradient.NONE));
+        expectedCombinations.add(ExpectedWriteOptionsCombination.defaultOptions().format(Format.ION_BINARY).ionMinorVersion(1).ionInlineSymbols(Gradient.NONE).ionDelimitedContainers(Gradient.ALL));
+        expectedCombinations.add(ExpectedWriteOptionsCombination.defaultOptions().format(Format.ION_BINARY).ionMinorVersion(1).ionInlineSymbols(Gradient.ALL).ionDelimitedContainers(Gradient.ALL));
+        expectedCombinations.add(ExpectedWriteOptionsCombination.defaultOptions().format(Format.ION_BINARY).ionMinorVersion(1).ionInlineSymbols(Gradient.ALL));
+        expectedCombinations.add(ExpectedWriteOptionsCombination.defaultOptions().format(Format.ION_BINARY).ionMinorVersion(1).ionInlineSymbols(Gradient.NONE));
+        expectedCombinations.add(ExpectedWriteOptionsCombination.defaultOptions().format(Format.ION_BINARY).ionMinorVersion(1).ionDelimitedContainers(Gradient.ALL));
+        expectedCombinations.add(ExpectedWriteOptionsCombination.defaultOptions().format(Format.ION_BINARY).ionMinorVersion(1).ionDelimitedContainers(Gradient.NONE));
+
+        for (WriteOptionsCombination optionsCombination : optionsCombinations) {
+            expectedCombinations.removeIf(candidate -> nullSafeEquals(candidate.ionMinorVersion, 0) ||
+                (nullSafeEquals(candidate.ionInlineSymbols, optionsCombination.ionInlineSymbols)
+                    && nullSafeEquals(candidate.ionDelimitedContainers, optionsCombination.ionDelimitedContainers)));
+
+            assertWriteTaskExecutesCorrectly(file, optionsCombination, optionsCombination.format, IoType.FILE);
+        }
+        assertTrue(expectedCombinations.isEmpty());
+    }
+
+    @Test
+    public void writeIonWithInlineSymbolsAndDelimitedContainers() throws Exception {
+        writeIonWithInlineSymbolsAndDelimitedContainers("binaryAllTypes.10n");
+        writeIonWithInlineSymbolsAndDelimitedContainers("binaryAllTypes11.10n");
     }
 }


### PR DESCRIPTION
### Description of changes:

Example output for command `ion-java-benchmark-cli write --warmups 2 --iterations 2 --forks 2 --mode AverageTime --ion-minor-version 0 --ion-minor-version 1 --ion-inline-symbols all --ion-delimited-containers none --ion-inline-symbols none --ion-delimited-containers all --ion-flush-period 500  log.ion`

Note: N = `--ion-inline-symbols`, C = `--ion-delimited-containers`

```
Benchmark                                   (input)                                                         (options)  Mode  Cnt          Score          Error   Units

Bench.run                                   log.ion    write::{f:ION_BINARY,t:FILE,d:500,a:STREAMING,V:1,N:ALL,C:ALL}  avgt    4        254.567 ±       15.968   ms/op
Bench.run:Heap usage                        log.ion    write::{f:ION_BINARY,t:FILE,d:500,a:STREAMING,V:1,N:ALL,C:ALL}  avgt    4        446.666 ±      250.743      MB
Bench.run:Serialized size                   log.ion    write::{f:ION_BINARY,t:FILE,d:500,a:STREAMING,V:1,N:ALL,C:ALL}  avgt    4        116.496                     MB

Bench.run                                   log.ion                write::{f:ION_BINARY,t:FILE,d:500,a:STREAMING,V:0}  avgt    4        202.997 ±       67.386   ms/op
Bench.run:Heap usage                        log.ion                write::{f:ION_BINARY,t:FILE,d:500,a:STREAMING,V:0}  avgt    4        367.582 ±      374.341      MB
Bench.run:Serialized size                   log.ion                write::{f:ION_BINARY,t:FILE,d:500,a:STREAMING,V:0}  avgt    4         21.396                     MB

Bench.run                                   log.ion   write::{f:ION_BINARY,t:FILE,d:500,a:STREAMING,V:1,N:NONE,C:ALL}  avgt    4        174.974 ±       13.372   ms/op
Bench.run:Heap usage                        log.ion   write::{f:ION_BINARY,t:FILE,d:500,a:STREAMING,V:1,N:NONE,C:ALL}  avgt    4        342.455 ±      426.056      MB
Bench.run:Serialized size                   log.ion   write::{f:ION_BINARY,t:FILE,d:500,a:STREAMING,V:1,N:NONE,C:ALL}  avgt    4         22.304                     MB

Bench.run                                   log.ion   write::{f:ION_BINARY,t:FILE,d:500,a:STREAMING,V:1,N:ALL,C:NONE}  avgt    4        308.391 ±       61.220   ms/op
Bench.run:Heap usage                        log.ion   write::{f:ION_BINARY,t:FILE,d:500,a:STREAMING,V:1,N:ALL,C:NONE}  avgt    4        418.646 ±     1104.092      MB
Bench.run:Serialized size                   log.ion   write::{f:ION_BINARY,t:FILE,d:500,a:STREAMING,V:1,N:ALL,C:NONE}  avgt    4        116.526                     MB

Bench.run                                   log.ion  write::{f:ION_BINARY,t:FILE,d:500,a:STREAMING,V:1,N:NONE,C:NONE}  avgt    4        188.626 ±       19.387   ms/op
Bench.run:Heap usage                        log.ion  write::{f:ION_BINARY,t:FILE,d:500,a:STREAMING,V:1,N:NONE,C:NONE}  avgt    4        341.320 ±      334.202      MB
Bench.run:Serialized size                   log.ion  write::{f:ION_BINARY,t:FILE,d:500,a:STREAMING,V:1,N:NONE,C:NONE}  avgt    4         19.311                     MB
```

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
