### PR TITLE
Allows reader buffer configuration to be applied to both continuable and non-continuable binary readers.

### DIFF
--- a/src/com/amazon/ion/benchmark/IonMeasurableReadTask.java
+++ b/src/com/amazon/ion/benchmark/IonMeasurableReadTask.java
@@ -76,22 +76,20 @@ class IonMeasurableReadTask extends MeasurableReadTask {
         // chosen with knowledge of the actual size of the data.
         readerBuilder = IonUtilities.newReaderBuilderForBenchmark(options).
             withIncrementalReadingEnabled(options.readerType == IonReaderType.INCREMENTAL);
-        if (readerBuilder.isIncrementalReadingEnabled()) {
-            if (options.initialBufferSize != null) {
+        if (options.initialBufferSize != null) {
+            readerBuilder.withBufferConfiguration(
+                IonBufferConfiguration.Builder.standard()
+                    .withInitialBufferSize(options.initialBufferSize)
+                    .build()
+            );
+        } else {
+            long inputSize = inputFile.length();
+            if (inputSize < DEFAULT_INCREMENTAL_BUFFER_SIZE) {
                 readerBuilder.withBufferConfiguration(
                     IonBufferConfiguration.Builder.standard()
-                        .withInitialBufferSize(options.initialBufferSize)
+                        .withInitialBufferSize(nextPowerOfTwo((int) inputSize))
                         .build()
                 );
-            } else {
-                long inputSize = inputFile.length();
-                if (inputSize < DEFAULT_INCREMENTAL_BUFFER_SIZE) {
-                    readerBuilder.withBufferConfiguration(
-                        IonBufferConfiguration.Builder.standard()
-                            .withInitialBufferSize(nextPowerOfTwo((int) inputSize))
-                            .build()
-                    );
-                }
             }
         }
     }

--- a/src/com/amazon/ion/benchmark/ReadOptionsMatrix.java
+++ b/src/com/amazon/ion/benchmark/ReadOptionsMatrix.java
@@ -78,11 +78,7 @@ class ReadOptionsMatrix extends OptionsMatrixBase {
             ION_SYSTEM::newInt,
             optionsCombinationStructs,
             () -> ION_SYSTEM.newSymbol(Constants.AUTO_VALUE),
-            (struct) -> {
-                // Do not apply this option to any options combinations that do not specify the incremental reader.
-                return OPTION_ONLY_APPLIES_TO_ION_BINARY.test(struct) &&
-                    IonReaderType.INCREMENTAL.name().equals(getStringValue(struct, ION_READER_NAME));
-            }
+            OPTION_ONLY_APPLIES_TO_ION_BINARY
         );
     }
 

--- a/tst/com/amazon/ion/benchmark/OptionsTest.java
+++ b/tst/com/amazon/ion/benchmark/OptionsTest.java
@@ -1486,12 +1486,13 @@ public class OptionsTest {
             "incremental",
             "binaryLargeLobs.10n"
         );
-        assertEquals(4, optionsCombinations.size());
-        List<ExpectedReadOptionsCombination> expectedCombinations = new ArrayList<>(4);
+        assertEquals(5, optionsCombinations.size());
+        List<ExpectedReadOptionsCombination> expectedCombinations = new ArrayList<>(5);
         expectedCombinations.add(ExpectedReadOptionsCombination.defaultOptions().format(Format.ION_TEXT));
         expectedCombinations.add(ExpectedReadOptionsCombination.defaultOptions().readerType(IonReaderType.INCREMENTAL).format(Format.ION_BINARY));
         expectedCombinations.add(ExpectedReadOptionsCombination.defaultOptions().readerType(IonReaderType.NON_INCREMENTAL).format(Format.ION_BINARY));
         expectedCombinations.add(ExpectedReadOptionsCombination.defaultOptions().initialBufferSize(128).readerType(IonReaderType.INCREMENTAL).format(Format.ION_BINARY));
+        expectedCombinations.add(ExpectedReadOptionsCombination.defaultOptions().initialBufferSize(128).readerType(IonReaderType.NON_INCREMENTAL).format(Format.ION_BINARY));
 
         for (ReadOptionsCombination optionsCombination : optionsCombinations) {
             expectedCombinations.removeIf(candidate -> {


### PR DESCRIPTION
### Description of changes:

When this option was initially authored, the continuable (i.e. incremental) and non-continuable readers had completely different implementations, and only the continuable one supported custom buffer configuration. Those implementations have since been unified, and both support the same configuration. This PR just allows the option to be applied to both types of binary readers.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
