### PR TITLE
Allows symbol table boundaries to be preserved when converting from Ion 1.0 to Ion 1.1.

### DIFF
--- a/src/com/amazon/ion/benchmark/Constants.java
+++ b/src/com/amazon/ion/benchmark/Constants.java
@@ -3,8 +3,11 @@ package com.amazon.ion.benchmark;
 import com.amazon.ion.IonSystem;
 import com.amazon.ion.system.IonSystemBuilder;
 
+import java.nio.charset.StandardCharsets;
+
 class Constants {
     static final IonSystem ION_SYSTEM = IonSystemBuilder.standard().build();
+    static final byte[] ION_1_1_TEXT_IVM = "$ion_1_1".getBytes(StandardCharsets.UTF_8);
     static final String LIMIT_NAME = "n";
     static final String PREALLOCATION_NAME = "L";
     static final String FLUSH_PERIOD_NAME = "d";

--- a/src/com/amazon/ion/benchmark/Format.java
+++ b/src/com/amazon/ion/benchmark/Format.java
@@ -29,7 +29,7 @@ enum Format {
                         || !IonUtilities.importsFilesEqual(options.importsForInputFile, options.importsForBenchmarkFile);
                     if (optionsRequireRewrite) {
                         // This combination of settings requires re-encoding the input.
-                        IonUtilities.rewriteIonFile(input, output, options, IonUtilities::newBinaryWriterSupplier);
+                        IonUtilities.rewriteIonFile(ION_BINARY, input, output, options, IonUtilities::newBinaryWriterSupplier);
                     } else if (options.limit == Integer.MAX_VALUE) {
                         // There are no settings that require mutating the original input.
                         return input;
@@ -39,12 +39,12 @@ enum Format {
                     }
                     break;
                 case ION_TEXT:
-                    IonUtilities.rewriteIonFile(input, output, options, IonUtilities::newBinaryWriterSupplier);
+                    IonUtilities.rewriteIonFile(ION_TEXT, input, output, options, IonUtilities::newBinaryWriterSupplier);
                     break;
                 case JSON:
                     // TODO add an option to "upconvert" from JSON. For example, detect timestamps contained in
                     // JSON strings and write them as Ion timestamps.
-                    IonUtilities.rewriteIonFile(input, output, options, IonUtilities::newBinaryWriterSupplier);
+                    IonUtilities.rewriteIonFile(JSON, input, output, options, IonUtilities::newBinaryWriterSupplier);
                     break;
                 case CBOR:
                     // TODO add an option to "upconvert" from CBOR. For example, detect symbol values.
@@ -89,15 +89,15 @@ enum Format {
                         // The input is already text and it is not being limited.
                         return input;
                     }
-                    IonUtilities.rewriteIonFile(input, output, options, IonUtilities::newTextWriterSupplier);
+                    IonUtilities.rewriteIonFile(ION_TEXT, input, output, options, IonUtilities::newTextWriterSupplier);
                     break;
                 case ION_BINARY:
-                    IonUtilities.rewriteIonFile(input, output, options, IonUtilities::newTextWriterSupplier);
+                    IonUtilities.rewriteIonFile(ION_BINARY, input, output, options, IonUtilities::newTextWriterSupplier);
                     break;
                 case JSON:
                     // TODO add an option to "upconvert" from JSON. For example, detect timestamps contained in
                     // JSON strings and write them as Ion timestamps.
-                    IonUtilities.rewriteIonFile(input, output, options, IonUtilities::newTextWriterSupplier);
+                    IonUtilities.rewriteIonFile(JSON, input, output, options, IonUtilities::newTextWriterSupplier);
                     break;
                 case CBOR:
                     // TODO add an option to "upconvert" from CBOR. For example, detect symbol values.
@@ -140,7 +140,7 @@ enum Format {
                 case ION_TEXT:
                 case ION_BINARY:
                     // Down-convert to JSON.
-                    IonUtilities.rewriteIonFile(input, output, options, IonUtilities::newJsonWriterSupplier);
+                    IonUtilities.rewriteIonFile(ION_BINARY, input, output, options, IonUtilities::newJsonWriterSupplier);
                     break;
                 case JSON:
                     if (options.limit == Integer.MAX_VALUE) {
@@ -188,7 +188,7 @@ enum Format {
             switch (sourceFormat) {
                 case ION_BINARY:
                 case ION_TEXT:
-                    IonUtilities.rewriteIonFile(input, output, options, IonUtilities::newCborWriterSupplier);
+                    IonUtilities.rewriteIonFile(ION_BINARY, input, output, options, IonUtilities::newCborWriterSupplier);
                     break;
                 case JSON:
                     JacksonUtilities.rewriteJsonToCbor(input, output, options);

--- a/src/com/amazon/ion/benchmark/IonUtilities.java
+++ b/src/com/amazon/ion/benchmark/IonUtilities.java
@@ -11,6 +11,7 @@ import com.amazon.ion.SpanProvider;
 import com.amazon.ion.SymbolTable;
 import com.amazon.ion.impl._Private_IonConstants;
 import com.amazon.ion.impl._Private_IonSystem;
+import com.amazon.ion.impl._Private_IonWriter;
 import com.amazon.ion.impl.bin.DelimitedContainerStrategy;
 import com.amazon.ion.impl.bin.SymbolInliningStrategy;
 import com.amazon.ion.impl.bin._Private_IonManagedBinaryWriterBuilder;
@@ -404,21 +405,52 @@ class IonUtilities {
         return input;
     }
 
+    @FunctionalInterface
+    interface TranscodeFunction {
+
+        /**
+         * Transcodes a value from the given reader to the given writer.
+         * @param reader a reader positioned on a value.
+         * @param writer a writer.
+         * @throws IOException if thrown during writing.
+         */
+        void transcode(IonReader reader, IonWriter writer) throws IOException;
+    }
+
+    /**
+     * Performs a standard transcode using {@link IonWriter#writeValue(IonReader)}, without transforming symbol IDs.
+     */
+    private static final TranscodeFunction STANDARD_TRANSCODE = (reader, writer) -> writer.writeValue(reader);
+
+    /**
+     * Transcodes using {@link _Private_IonWriter#writeValue(IonReader, _Private_IonWriter.IntTransformer)},
+     * transforming Ion 1.0 local symbol IDs to the Ion 1.1 equivalents.
+     */
+    private static final TranscodeFunction TRANSCODE_1_0_TO_1_1 = (reader, writer) -> {
+        ((_Private_IonWriter) writer).writeValue(reader, _Private_IonWriter.ION_1_0_SID_TO_ION_1_1_SID);
+    };
+
     /**
      * Rewrite values using the given options.
      * @param reader reader over the input data.
      * @param writer writer to the output data.
      * @param options the options to use when re-writing.
+     * @param transcodeFunction the function to use to transcode a value from a reader to a writer.
      * @throws IOException if thrown when reading or writing.
      */
-    private static void writeValuesWithOptions(IonReader reader, IonWriter writer, OptionsCombinationBase options) throws IOException {
+    private static void writeValuesWithOptions(
+        IonReader reader,
+        IonWriter writer,
+        OptionsCombinationBase options,
+        TranscodeFunction transcodeFunction
+    ) throws IOException {
         int i = 0;
         boolean isUnlimited = options.limit == Integer.MAX_VALUE;
         while (isUnlimited || i < options.limit) {
             if (reader.next() == null) {
                 break;
             }
-            writer.writeValue(reader);
+            transcodeFunction.transcode(reader, writer);
             if (options.flushPeriod != null && i % options.flushPeriod == 0) {
                 writer.flush();
             }
@@ -441,6 +473,7 @@ class IonUtilities {
         IonUtilities.IonWriterSupplier writerSupplier = writerSupplierFactory.get(options);
         IonWriter writer = null;
         IonReader reader = null;
+        TranscodeFunction transcodeFunction = STANDARD_TRANSCODE;
         try {
             if (
                 options.flushPeriod == null &&
@@ -454,12 +487,17 @@ class IonUtilities {
                 // Use system-level reader to preserve the same symbol tables from the input.
                 writer = writerSupplier.get(options.newOutputStream(outputFile));
                 reader = ((_Private_IonSystem) ION_SYSTEM).newSystemReader(options.newInputStream(inputFile));
+                if (options.ionMinorVersion > getMinorVersion(inputFormat, input.toFile())) {
+                    // Because symbol IDs will be transferred during the system transcode, *and* this is a format
+                    // upgrade, the symbol IDs need to be transformed to point to the same text in the new format.
+                    transcodeFunction = TRANSCODE_1_0_TO_1_1;
+                }
             } else {
                 // Do not preserve the existing symbol table boundaries.
                 writer = writerSupplier.get(options.newOutputStream(outputFile));
                 reader = newReaderBuilderForInput(options).build(options.newInputStream(inputFile));
             }
-            writeValuesWithOptions(reader, writer, options);
+            writeValuesWithOptions(reader, writer, options, transcodeFunction);
         } finally {
             if (writer != null) {
                 writer.close();
@@ -488,7 +526,7 @@ class IonUtilities {
             IonReader reader = new IonReaderFromCbor(JacksonUtilities.newCborFactoryForInput(options).createParser(input.toFile()));
             IonWriter writer = writerSupplierFactory.get(options).get(options.newOutputStream(output.toFile()));
         ) {
-            writeValuesWithOptions(reader, writer, options);
+            writeValuesWithOptions(reader, writer, options, STANDARD_TRANSCODE);
         }
     }
 

--- a/src/com/amazon/ion/benchmark/IonUtilities.java
+++ b/src/com/amazon/ion/benchmark/IonUtilities.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.amazon.ion.benchmark.Constants.ION_1_1_TEXT_IVM;
 import static com.amazon.ion.benchmark.Constants.ION_SYSTEM;
 
 /**
@@ -175,6 +176,32 @@ class IonUtilities {
             return isFormatHeaderPresent(_Private_IonConstants.BINARY_VERSION_MARKER_1_0, input);
         }
         throw new IllegalStateException("Unknown Ion minor version: " + minorVersion);
+    }
+
+    /**
+     * Get the minor version for the given text or binary Ion file.
+     * @param inputFormat the format of 'input'; must be ION_BINARY, ION_TEXT, or JSON.
+     * @param input the file to examine.
+     * @return the Ion minor version of the data in the input file.
+     * @throws IOException if thrown while reading the file.
+     */
+    static int getMinorVersion(Format inputFormat, File input) throws IOException {
+        if (inputFormat == Format.ION_BINARY) {
+            if (isFormatHeaderPresent(_Private_IonConstants.BINARY_VERSION_MARKER_1_0, input)) {
+                return 0;
+            }
+            if (isFormatHeaderPresent(_Private_IonConstants.BINARY_VERSION_MARKER_1_1, input)) {
+                return 1;
+            }
+        } else if (inputFormat == Format.ION_TEXT) {
+            if (isFormatHeaderPresent(ION_1_1_TEXT_IVM, input)) {
+                return 1;
+            }
+            return 0;
+        } else if (inputFormat == Format.JSON) {
+            return 0;
+        }
+        throw new IllegalStateException("File is either not Ion or has unknown minor version: " + input);
     }
 
     /**
@@ -401,13 +428,14 @@ class IonUtilities {
 
     /**
      * Rewrite the given Ion file using the given options.
+     * @param inputFormat the format of 'input'; must be ION_BINARY, ION_TEXT, or JSON.
      * @param input path to the file to re-write.
      * @param output path to the destination file.
      * @param options the options to use when rewriting.
      * @param writerSupplierFactory IonWriterSupplierFactory for retrieving suppliers of IonWriters with the given options.
      * @throws IOException if thrown when reading or writing.
      */
-    static void rewriteIonFile(Path input, Path output, OptionsCombinationBase options, IonWriterSupplierFactory writerSupplierFactory) throws IOException {
+    static void rewriteIonFile(Format inputFormat, Path input, Path output, OptionsCombinationBase options, IonWriterSupplierFactory writerSupplierFactory) throws IOException {
         File inputFile = input.toFile();
         File outputFile = output.toFile();
         IonUtilities.IonWriterSupplier writerSupplier = writerSupplierFactory.get(options);
@@ -419,8 +447,9 @@ class IonUtilities {
                 options.importsForInputFile == null &&
                 options.importsForBenchmarkFile == null &&
                 options.format == Format.ION_BINARY &&
-                options.ionMinorVersion != 1 && // TODO remove once support for writing system values via the Ion 1.1 writer is added.
-                IonUtilities.minorVersionsEqual(options.ionMinorVersion, input.toFile())
+                // Minor versions may add new kinds of system values, so it is not possible to maintain system value
+                // boundaries when downgrading to a previous minor version.
+                getMinorVersion(inputFormat, input.toFile()) <= options.ionMinorVersion
             ) {
                 // Use system-level reader to preserve the same symbol tables from the input.
                 writer = writerSupplier.get(options.newOutputStream(outputFile));

--- a/tst/com/amazon/ion/benchmark/OptionsTest.java
+++ b/tst/com/amazon/ion/benchmark/OptionsTest.java
@@ -3,7 +3,9 @@ package com.amazon.ion.benchmark;
 import com.amazon.ion.IonDatagram;
 import com.amazon.ion.IonReader;
 import com.amazon.ion.IonSystem;
+import com.amazon.ion.IonType;
 import com.amazon.ion.SymbolTable;
+import com.amazon.ion.impl._Private_IonSystem;
 import com.amazon.ion.system.IonReaderBuilder;
 import com.amazon.ion.util.Equivalence;
 import com.amazon.ion.util.IonStreamUtils;
@@ -26,6 +28,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 
+import static com.amazon.ion.benchmark.Constants.ION_SYSTEM;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -2193,6 +2196,72 @@ public class OptionsTest {
             Format.ION_BINARY,
             IoType.BUFFER
         );
+    }
+
+    /**
+     * Converts "multipleLocalSymbolTables.ion" to the requested minor version and asserts that the symbol table
+     * boundaries are preserved.
+     * @param outputMinorVersion the desired minor version.
+     * @throws Exception if conversion fails.
+     */
+    private void convertAndVerifySymbolTableBoundaries(int outputMinorVersion) throws Exception {
+        WriteOptionsCombination optionsCombination = parseSingleOptionsCombination(
+            "write",
+            "--ion-minor-version",
+            "" + outputMinorVersion,
+            "multipleLocalSymbolTables.ion"
+        );
+        Path input = fileInTestDirectory("multipleLocalSymbolTables.ion");
+        Path output = TemporaryFiles.newTempFile("multipleLocalSymbolTables_1_" + outputMinorVersion, ".10n");
+        String ionVersionMarkerString = "$ion_1_" + outputMinorVersion;
+        Format.ION_BINARY.convert(input, output, optionsCombination);
+        // Because the input and output versions have compatible system values, the system values should be preserved.
+        try (IonReader reader = ((_Private_IonSystem) ION_SYSTEM).newSystemReader(optionsCombination.newInputStream(output.toFile()))) {
+            assertEquals(IonType.SYMBOL, reader.next());
+            while (reader.getType() == IonType.SYMBOL) {
+                // If the output starts with more than one IVM, that's not harmful.
+                assertEquals(ionVersionMarkerString, reader.stringValue());
+                reader.next();
+            }
+            SymbolTable systemSymbolTable = reader.getSymbolTable();
+            int firstLocalSid = systemSymbolTable.getMaxId() + 1;
+            assertEquals(IonType.STRUCT, reader.getType());
+            assertEquals("$ion_symbol_table", reader.getTypeAnnotations()[0]);
+            assertEquals(IonType.SYMBOL, reader.next());
+            assertEquals(firstLocalSid, reader.symbolValue().getSid());
+            assertEquals(IonType.STRUCT, reader.next());
+            assertEquals("$ion_symbol_table", reader.getTypeAnnotations()[0]);
+            reader.stepIn();
+            assertEquals(IonType.SYMBOL, reader.next());
+            assertEquals("$ion_symbol_table", reader.stringValue()); // An LST append.
+            reader.stepOut();
+            assertEquals(IonType.SYMBOL, reader.next());
+            assertEquals(firstLocalSid + 1, reader.symbolValue().getSid());
+            assertEquals(IonType.STRUCT, reader.next());
+            assertEquals("$ion_symbol_table", reader.getTypeAnnotations()[0]);
+            assertEquals(IonType.SYMBOL, reader.next());
+            assertEquals(firstLocalSid, reader.symbolValue().getSid()); // The symbol table did not append, so the SIDs reset.
+            assertNull(reader.next());
+        }
+        // Now read with the user-level reader and verify the user values are as expected.
+        try (IonReader reader = IonReaderBuilder.standard().build(optionsCombination.newInputStream(output.toFile()))) {
+            assertEquals(IonType.SYMBOL, reader.next());
+            assertEquals("a", reader.stringValue());
+            assertEquals(IonType.SYMBOL, reader.next());
+            assertEquals("b", reader.stringValue());
+            assertEquals(IonType.SYMBOL, reader.next());
+            assertEquals("c", reader.stringValue());
+        }
+    }
+
+    @Test
+    public void rewriteIon10PreservesSymbolTables() throws Exception {
+        convertAndVerifySymbolTableBoundaries(0);
+    }
+
+    @Test
+    public void convertIon10ToIon11PreservesSymbolTables() throws Exception {
+        convertAndVerifySymbolTableBoundaries(1);
     }
 
     private void writeAllTypes10And11(String file) throws Exception {

--- a/tst/com/amazon/ion/benchmark/multipleLocalSymbolTables.ion
+++ b/tst/com/amazon/ion/benchmark/multipleLocalSymbolTables.ion
@@ -1,0 +1,14 @@
+$ion_1_0
+$ion_symbol_table::{
+    symbols: ["a"]
+}
+$10
+$ion_symbol_table::{
+    imports: $ion_symbol_table,
+    symbols: ["b"]
+}
+$11
+$ion_symbol_table::{
+    symbols: ["c"]
+}
+$10


### PR DESCRIPTION
### Issue #, if available:
Fixes #62 

### Description of changes:
This allows more direct performance comparisons between Ion 1.0 and Ion 1.1. Note: ion-java's 1.1 writer needs to flush upon encountering a system value in order to achieve comparable performance to the Ion 1.0 writer (see https://github.com/amazon-ion/ion-java/issues/873).

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
