### PR TITLE
Upgrades JMH to 1.37 and adds an explicit plugin dependency on jmh-generator-annprocess.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,13 +79,13 @@
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
-            <version>1.23</version>
+            <version>1.37</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.openjdk.jmh/jmh-generator-annprocess -->
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-generator-annprocess</artifactId>
-            <version>1.23</version>
+            <version>1.37</version>
         </dependency>
         <dependency>
             <groupId>com.offbytwo</groupId>
@@ -117,6 +117,13 @@
                 <configuration>
                     <source>8</source>
                     <target>8</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.openjdk.jmh</groupId>
+                            <artifactId>jmh-generator-annprocess</artifactId>
+                            <version>1.37</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
### Description of changes:

Adding an explicit plugin dependency on jmh-generator-annprocess resolves the runtime error "ERROR: Unable to find the resource: /META-INF/BenchmarkList" that some developers have experienced.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
