### PR TITLE
Add Support for IonElement

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,17 +101,28 @@ ion-java-benchmark write --ion-imports-for-benchmark tables.ion \
 Benchmark a full-traversal read of data equivalent to exampleWithImports.10n, which declares the shared
 symbol table imports provided by inputTables.ion, re-encoded (if necessary) using the shared symbol
 tables provided by benchmarkTables.ion, inputTables.ion, and no shared symbol tables. Produce
-results from using both the DOM and IonReader APIs.
+results from using the DOM, IonReader and IonElement APIs.
 
 ```
 ion-java-benchmark read --ion-imports-for-input inputTables.ion \
                         --ion-imports-for-benchmark benchmarkTables.ion \
                         --ion-imports-for-benchmark auto \
                         --ion-imports-for-benchmark none \
-                        --ion-api dom \
-                        --ion-api streaming \
+                        --api dom \
+                        --api streaming \
+                        --api ion_element_dom \
                         exampleWithImports.10n
 ```
+
+Benchmark a full-traversal read of `example.10n` using the IonElement API from ion-element-kotlin,
+comparing performance against the traditional DOM API.
+
+```
+ion-java-benchmark read --api dom \
+                        --api ion_element_dom \
+                        example.10n
+```
+
 
 ## Tips
 

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>com.amazon.ion</groupId>
             <artifactId>ion-element</artifactId>
-            <version>1.3.0</version>
+            <version>[1.3.0, )</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,21 @@
             <artifactId>ion-java-path-extraction</artifactId>
             <version>1.2.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.amazon.ion</groupId>
+            <artifactId>ion-element</artifactId>
+            <version>1.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <version>1.6.20</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-collections-immutable-jvm</artifactId>
+            <version>0.3.4</version>
+        </dependency>
         <!-- test dependencies -->
         <dependency>
           <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,13 @@
                 <configuration>
                     <source>8</source>
                     <target>8</target>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.openjdk.jmh</groupId>
+                            <artifactId>jmh-generator-annprocess</artifactId>
+                            <version>1.23</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/com/amazon/ion/benchmark/API.java
+++ b/src/com/amazon/ion/benchmark/API.java
@@ -13,5 +13,10 @@ enum API {
     /**
      * For Ion: the DOM APIs (IonLoader, IonValue, etc.). For JSON (Jackson): JsonNode via ObjectMapper.
      */
-    DOM
+    DOM,
+
+    /**
+     * For Ion: the IonElement APIs from ion-element-kotlin. For JSON (Jackson): Not supported.
+     */
+    ION_ELEMENT_DOM
 }

--- a/src/com/amazon/ion/benchmark/CborJacksonMeasurableReadTask.java
+++ b/src/com/amazon/ion/benchmark/CborJacksonMeasurableReadTask.java
@@ -150,10 +150,11 @@ public class CborJacksonMeasurableReadTask extends MeasurableReadTask {
 
     @Override
     void fullyReadDomFromFile(SideEffectConsumer consumer) throws IOException {
-        sideEffectConsumer = consumer;
-        CBORMapper objectMapper = new CBORMapper(cborFactory);
-        JsonNode tree = objectMapper.readTree(options.newInputStream(inputFile));
-        consumer.consume(tree);
+        CBORMapper mapper = JacksonUtilities.newCborObjectMapper(cborFactory, options);
+        Iterator<JsonNode> iterator = mapper.reader().createParser(options.newInputStream(inputFile)).readValuesAs(JsonNode.class);
+        while (iterator.hasNext()) {
+            consumer.consume(iterator.next());
+        }
     }
 
     @Override

--- a/src/com/amazon/ion/benchmark/CborJacksonMeasurableReadTask.java
+++ b/src/com/amazon/ion/benchmark/CborJacksonMeasurableReadTask.java
@@ -150,10 +150,19 @@ public class CborJacksonMeasurableReadTask extends MeasurableReadTask {
 
     @Override
     void fullyReadDomFromFile(SideEffectConsumer consumer) throws IOException {
-        CBORMapper mapper = JacksonUtilities.newCborObjectMapper(cborFactory, options);
-        Iterator<JsonNode> iterator = mapper.reader().createParser(options.newInputStream(inputFile)).readValuesAs(JsonNode.class);
-        while (iterator.hasNext()) {
-            consumer.consume(iterator.next());
-        }
+        sideEffectConsumer = consumer;
+        CBORMapper objectMapper = new CBORMapper(cborFactory);
+        JsonNode tree = objectMapper.readTree(options.newInputStream(inputFile));
+        consumer.consume(tree);
+    }
+
+    @Override
+    public void fullyReadElementFromBuffer(SideEffectConsumer consumer) throws IOException {
+        throw new UnsupportedOperationException("IonElement API is not supported for CBOR format. Use ion_binary or ion_text format instead.");
+    }
+
+    @Override
+    public void fullyReadElementFromFile(SideEffectConsumer consumer) throws IOException {
+        throw new UnsupportedOperationException("IonElement API is not supported for CBOR format. Use ion_binary or ion_text format instead.");
     }
 }

--- a/src/com/amazon/ion/benchmark/CborJacksonMeasurableWriteTask.java
+++ b/src/com/amazon/ion/benchmark/CborJacksonMeasurableWriteTask.java
@@ -150,4 +150,9 @@ public class CborJacksonMeasurableWriteTask extends MeasurableWriteTask<CBORGene
     void closeWriter(CBORGenerator generator) throws IOException {
         generator.close();
     }
+
+    @Override
+    void generateWriteInstructionsElement(Consumer<WriteInstruction<CBORGenerator>> instructionsSink) throws IOException {
+        throw new UnsupportedOperationException("IonElement API is not supported for CBOR format. Use ion_binary or ion_text format instead.");
+    }
 }

--- a/src/com/amazon/ion/benchmark/IonMeasurableReadTask.java
+++ b/src/com/amazon/ion/benchmark/IonMeasurableReadTask.java
@@ -9,7 +9,7 @@ import com.amazon.ionpathextraction.PathExtractor;
 import com.amazon.ionpathextraction.PathExtractorBuilder;
 import com.amazon.ionelement.api.AnyElement;
 import com.amazon.ionelement.api.IonElementLoader;
-import com.amazon.ionelement.api.IonElementLoaderOptions;
+import com.amazon.ionelement.api.ElementLoader;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/src/com/amazon/ion/benchmark/IonMeasurableReadTask.java
+++ b/src/com/amazon/ion/benchmark/IonMeasurableReadTask.java
@@ -249,7 +249,9 @@ class IonMeasurableReadTask extends MeasurableReadTask {
     public void fullyReadDomFromBuffer(SideEffectConsumer consumer) throws IOException {
         sideEffectConsumer = consumer;
         IonReader reader = readerBuilder.build(buffer);
-        ionSystem.newLoader().load(reader);
+        for (com.amazon.ion.IonValue value : ionSystem.newLoader().load(reader)) {
+            consumer.consume(value);
+        }
         reader.close();
     }
 
@@ -257,7 +259,9 @@ class IonMeasurableReadTask extends MeasurableReadTask {
     public void fullyReadDomFromFile(SideEffectConsumer consumer) throws IOException {
         sideEffectConsumer = consumer;
         IonReader reader = readerBuilder.build(options.newInputStream(inputFile));
-        ionSystem.newLoader().load(reader);
+        for (com.amazon.ion.IonValue value : ionSystem.newLoader().load(reader)) {
+            consumer.consume(value);
+        }
         reader.close();
     }
 

--- a/src/com/amazon/ion/benchmark/IonMeasurableReadTask.java
+++ b/src/com/amazon/ion/benchmark/IonMeasurableReadTask.java
@@ -74,9 +74,7 @@ class IonMeasurableReadTask extends MeasurableReadTask {
 
         // Initialize IonElement loader for ION_ELEMENT_DOM API
         if (options.api == API.ION_ELEMENT_DOM) {
-            elementLoader = new com.amazon.ionelement.impl.IonElementLoaderImpl(
-                    new IonElementLoaderOptions(false)
-            );
+            elementLoader = ElementLoader.createIonElementLoader();
         }
     }
 

--- a/src/com/amazon/ion/benchmark/IonMeasurableReadTask.java
+++ b/src/com/amazon/ion/benchmark/IonMeasurableReadTask.java
@@ -7,6 +7,9 @@ import com.amazon.ion.IonType;
 import com.amazon.ion.system.IonReaderBuilder;
 import com.amazon.ionpathextraction.PathExtractor;
 import com.amazon.ionpathextraction.PathExtractorBuilder;
+import com.amazon.ionelement.api.AnyElement;
+import com.amazon.ionelement.api.IonElementLoader;
+import com.amazon.ionelement.api.IonElementLoaderOptions;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -25,6 +28,7 @@ class IonMeasurableReadTask extends MeasurableReadTask {
     private final byte[] reusableLobBuffer;
     private IonReaderBuilder readerBuilder;
     private SideEffectConsumer sideEffectConsumer = null;
+    private IonElementLoader elementLoader;
 
     /**
      * Returns the next power of two greater than or equal to the given value.
@@ -66,6 +70,13 @@ class IonMeasurableReadTask extends MeasurableReadTask {
             reusableLobBuffer = new byte[DEFAULT_REUSABLE_LOB_BUFFER_SIZE];
         } else {
             reusableLobBuffer = null;
+        }
+
+        // Initialize IonElement loader for ION_ELEMENT_DOM API
+        if (options.api == API.ION_ELEMENT_DOM) {
+            elementLoader = new com.amazon.ionelement.impl.IonElementLoaderImpl(
+                    new IonElementLoaderOptions(false)
+            );
         }
     }
 
@@ -249,6 +260,28 @@ class IonMeasurableReadTask extends MeasurableReadTask {
         sideEffectConsumer = consumer;
         IonReader reader = readerBuilder.build(options.newInputStream(inputFile));
         ionSystem.newLoader().load(reader);
+        reader.close();
+    }
+
+    @Override
+    public void fullyReadElementFromBuffer(SideEffectConsumer consumer) throws IOException {
+        sideEffectConsumer = consumer;
+        IonReader reader = readerBuilder.build(buffer);
+        Iterable<AnyElement> elements = elementLoader.loadAllElements(reader);
+        for (AnyElement element : elements) {
+            consumer.consume(element);
+        }
+        reader.close();
+    }
+
+    @Override
+    public void fullyReadElementFromFile(SideEffectConsumer consumer) throws IOException {
+        sideEffectConsumer = consumer;
+        IonReader reader = readerBuilder.build(options.newInputStream(inputFile));
+        Iterable<AnyElement> elements = elementLoader.loadAllElements(reader);
+        for (AnyElement element : elements) {
+            consumer.consume(element);
+        }
         reader.close();
     }
 }

--- a/src/com/amazon/ion/benchmark/IonMeasurableWriteTask.java
+++ b/src/com/amazon/ion/benchmark/IonMeasurableWriteTask.java
@@ -48,9 +48,7 @@ class IonMeasurableWriteTask extends MeasurableWriteTask<IonWriter> {
 
         // Initialize IonElement loader for ION_ELEMENT_DOM API
         if (options.api == API.ION_ELEMENT_DOM) {
-            elementLoader = new com.amazon.ionelement.impl.IonElementLoaderImpl(
-                    new IonElementLoaderOptions(false)
-            );
+            elementLoader = ElementLoader.createIonElementLoader();
         }
     }
 

--- a/src/com/amazon/ion/benchmark/IonMeasurableWriteTask.java
+++ b/src/com/amazon/ion/benchmark/IonMeasurableWriteTask.java
@@ -9,7 +9,7 @@ import com.amazon.ion.SymbolToken;
 import com.amazon.ion.Timestamp;
 import com.amazon.ionelement.api.AnyElement;
 import com.amazon.ionelement.api.IonElementLoader;
-import com.amazon.ionelement.api.IonElementLoaderOptions;
+import com.amazon.ionelement.api.ElementLoader;
 
 import java.io.IOException;
 import java.io.OutputStream;

--- a/src/com/amazon/ion/benchmark/IonMeasurableWriteTask.java
+++ b/src/com/amazon/ion/benchmark/IonMeasurableWriteTask.java
@@ -216,11 +216,9 @@ class IonMeasurableWriteTask extends MeasurableWriteTask<IonWriter> {
         } else {
             List<AnyElement> limitedElements = new ArrayList<>();
             try (IonReader reader = IonUtilities.newReaderBuilderForInput(options).build(options.newInputStream(inputFile))) {
-                Iterable<AnyElement> allElements = elementLoader.loadAllElements(reader);
                 int count = 0;
-                for (AnyElement element : allElements) {
-                    limitedElements.add(element);
-                    if (++count >= options.limit) break;
+                while (count++ < options.limit && reader.next() != null) {
+                    limitedElements.add(elementLoader.loadCurrentElement(reader));
                 }
             }
             elements = limitedElements;

--- a/src/com/amazon/ion/benchmark/IonMeasurableWriteTask.java
+++ b/src/com/amazon/ion/benchmark/IonMeasurableWriteTask.java
@@ -7,13 +7,18 @@ import com.amazon.ion.IonValue;
 import com.amazon.ion.IonWriter;
 import com.amazon.ion.SymbolToken;
 import com.amazon.ion.Timestamp;
+import com.amazon.ionelement.api.AnyElement;
+import com.amazon.ionelement.api.IonElementLoader;
+import com.amazon.ionelement.api.IonElementLoaderOptions;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.function.Consumer;
 
 import static com.amazon.ion.benchmark.Constants.ION_SYSTEM;
@@ -24,6 +29,7 @@ import static com.amazon.ion.benchmark.Constants.ION_SYSTEM;
 class IonMeasurableWriteTask extends MeasurableWriteTask<IonWriter> {
 
     private final IonUtilities.IonWriterSupplier writerBuilder;
+    private IonElementLoader elementLoader;
 
     /**
      * @param inputPath path to the data to re-write.
@@ -38,6 +44,13 @@ class IonMeasurableWriteTask extends MeasurableWriteTask<IonWriter> {
             writerBuilder = IonUtilities.newBinaryWriterSupplier(options);
         } else {
             throw new IllegalStateException("IonFormatWriter is compatible only with ION_TEXT and ION_BINARY");
+        }
+
+        // Initialize IonElement loader for ION_ELEMENT_DOM API
+        if (options.api == API.ION_ELEMENT_DOM) {
+            elementLoader = new com.amazon.ionelement.impl.IonElementLoaderImpl(
+                    new IonElementLoaderOptions(false)
+            );
         }
     }
 
@@ -195,4 +208,35 @@ class IonMeasurableWriteTask extends MeasurableWriteTask<IonWriter> {
         writer.close();
     }
 
+    @Override
+    void generateWriteInstructionsElement(Consumer<WriteInstruction<IonWriter>> instructionsSink) throws IOException {
+        Iterable<AnyElement> elements;
+        if (options.limit == Integer.MAX_VALUE) {
+            try (IonReader reader = IonUtilities.newReaderBuilderForInput(options).build(options.newInputStream(inputFile))) {
+                elements = elementLoader.loadAllElements(reader);
+            }
+        } else {
+            List<AnyElement> limitedElements = new ArrayList<>();
+            try (IonReader reader = IonUtilities.newReaderBuilderForInput(options).build(options.newInputStream(inputFile))) {
+                Iterable<AnyElement> allElements = elementLoader.loadAllElements(reader);
+                int count = 0;
+                for (AnyElement element : allElements) {
+                    limitedElements.add(element);
+                    if (++count >= options.limit) break;
+                }
+            }
+            elements = limitedElements;
+        }
+
+        // Convert IonElements to write instructions
+        int elementCount = 0;
+        for (AnyElement element : elements) {
+            instructionsSink.accept(element::writeTo);
+            elementCount++;
+            if (options.flushPeriod != null && elementCount % options.flushPeriod == 0) {
+                instructionsSink.accept(IonWriter::flush);
+            }
+        }
+        instructionsSink.accept(IonWriter::finish);
+    }
 }

--- a/src/com/amazon/ion/benchmark/JsonJacksonMeasurableReadTask.java
+++ b/src/com/amazon/ion/benchmark/JsonJacksonMeasurableReadTask.java
@@ -139,10 +139,19 @@ public class JsonJacksonMeasurableReadTask extends MeasurableReadTask {
 
     @Override
     void fullyReadDomFromFile(SideEffectConsumer consumer) throws IOException {
-        ObjectMapper mapper = JacksonUtilities.newJsonObjectMapper(jsonFactory, options);
-        Iterator<JsonNode> iterator = mapper.reader().createParser(options.newInputStream(inputFile)).readValuesAs(JsonNode.class);
-        while (iterator.hasNext()) {
-            consumer.consume(iterator.next());
-        }
+        sideEffectConsumer = consumer;
+        ObjectMapper objectMapper = JacksonUtilities.newJsonObjectMapper(jsonFactory, options);
+        JsonNode tree = objectMapper.readTree(options.newInputStream(inputFile));
+        consumer.consume(tree);
+    }
+
+    @Override
+    public void fullyReadElementFromBuffer(SideEffectConsumer consumer) throws IOException {
+        throw new UnsupportedOperationException("IonElement API is not supported for JSON format. Use ion_binary or ion_text format instead.");
+    }
+
+    @Override
+    public void fullyReadElementFromFile(SideEffectConsumer consumer) throws IOException {
+        throw new UnsupportedOperationException("IonElement API is not supported for JSON format. Use ion_binary or ion_text format instead.");
     }
 }

--- a/src/com/amazon/ion/benchmark/JsonJacksonMeasurableReadTask.java
+++ b/src/com/amazon/ion/benchmark/JsonJacksonMeasurableReadTask.java
@@ -139,10 +139,11 @@ public class JsonJacksonMeasurableReadTask extends MeasurableReadTask {
 
     @Override
     void fullyReadDomFromFile(SideEffectConsumer consumer) throws IOException {
-        sideEffectConsumer = consumer;
-        ObjectMapper objectMapper = JacksonUtilities.newJsonObjectMapper(jsonFactory, options);
-        JsonNode tree = objectMapper.readTree(options.newInputStream(inputFile));
-        consumer.consume(tree);
+        ObjectMapper mapper = JacksonUtilities.newJsonObjectMapper(jsonFactory, options);
+        Iterator<JsonNode> iterator = mapper.reader().createParser(options.newInputStream(inputFile)).readValuesAs(JsonNode.class);
+        while (iterator.hasNext()) {
+            consumer.consume(iterator.next());
+        }
     }
 
     @Override

--- a/src/com/amazon/ion/benchmark/JsonJacksonMeasurableWriteTask.java
+++ b/src/com/amazon/ion/benchmark/JsonJacksonMeasurableWriteTask.java
@@ -142,4 +142,9 @@ class JsonJacksonMeasurableWriteTask extends MeasurableWriteTask<JsonGenerator> 
     void closeWriter(JsonGenerator generator) throws IOException {
         generator.close();
     }
+
+    @Override
+    void generateWriteInstructionsElement(Consumer<WriteInstruction<JsonGenerator>> instructionsSink) throws IOException {
+        throw new UnsupportedOperationException("IonElement API is not supported for JSON format. Use ion_binary or ion_text format instead.");
+    }
 }

--- a/src/com/amazon/ion/benchmark/Main.java
+++ b/src/com/amazon/ion/benchmark/Main.java
@@ -135,7 +135,7 @@ public class Main {
 
         + "  -a --api <api>                         The API to exercise (dom, streaming, or ion_element_dom). For the ion-binary or "
             + "ion-text formats, 'streaming' causes IonReader/IonWriter to be used while 'dom' causes IonLoader to be "
-            + "used, and 'ion_element_dom' causes IonElement from ion-element to be used with dedicated code paths. For Jackson JSON, 'streaming' causes JsonParser/JsonGenerator to be used while 'dom' causes "
+            + "used, and 'ion_element_dom' causes IonElement from ion-element-kotlin to be used with dedicated code paths. For Jackson JSON, 'streaming' causes JsonParser/JsonGenerator to be used while 'dom' causes "
             + "ObjectMapper to materialize JsonNode instances. 'ion_element_dom' is not supported for JSON or CBOR formats. May be specified multiple times to compare "
             + "APIs. [default: streaming]\n"
 

--- a/src/com/amazon/ion/benchmark/Main.java
+++ b/src/com/amazon/ion/benchmark/Main.java
@@ -133,10 +133,10 @@ public class Main {
         + "  -f --format <type>                     Format to benchmark, from the set (ion_binary | ion_text | json | "
             + "cbor). May be specified multiple times to compare different formats. [default: ion_binary]\n"
 
-        + "  -a --api <api>                         The API to exercise (dom or streaming). For the ion-binary or "
+        + "  -a --api <api>                         The API to exercise (dom, streaming, or ion_element_dom). For the ion-binary or "
             + "ion-text formats, 'streaming' causes IonReader/IonWriter to be used while 'dom' causes IonLoader to be "
-            + "used. For Jackson JSON, 'streaming' causes JsonParser/JsonGenerator to be used while 'dom' causes "
-            + "ObjectMapper to materialize JsonNode instances. May be specified multiple times to compare both "
+            + "used, and 'ion_element_dom' causes IonElement from ion-element to be used with dedicated code paths. For Jackson JSON, 'streaming' causes JsonParser/JsonGenerator to be used while 'dom' causes "
+            + "ObjectMapper to materialize JsonNode instances. 'ion_element_dom' is not supported for JSON or CBOR formats. May be specified multiple times to compare "
             + "APIs. [default: streaming]\n"
 
         + "  -I --ion-imports-for-input <file>      A file containing a sequence of Ion symbol tables, or the string "

--- a/src/com/amazon/ion/benchmark/MeasurableReadTask.java
+++ b/src/com/amazon/ion/benchmark/MeasurableReadTask.java
@@ -84,6 +84,20 @@ abstract class MeasurableReadTask implements MeasurableTask {
      */
     abstract void fullyReadDomFromFile(SideEffectConsumer consumer) throws IOException;
 
+    /**
+     * Initialize the element loader and perform a fully-materialized deep read of the data from a buffer using
+     * IonElement API. The "loader" is defined as any context that is tied to a single stream.
+     * @throws IOException if thrown during reading.
+     */
+    abstract void fullyReadElementFromBuffer(SideEffectConsumer consumer) throws IOException;
+
+    /**
+     * Initialize the element loader and perform a fully-materialized deep read of the data from a file using
+     * IonElement API. The "loader" is defined as any context that is tied to a single stream.
+     * @throws IOException if thrown during reading.
+     */
+    abstract void fullyReadElementFromFile(SideEffectConsumer consumer) throws IOException;
+
     @Override
     public void setUpTrial() throws IOException {
         inputFile = options.convertFileIfNecessary(originalFile).toFile();
@@ -123,6 +137,12 @@ abstract class MeasurableReadTask implements MeasurableTask {
                 return this::fullyReadDomFromBuffer;
             } else {
                 return this::fullyReadDomFromFile;
+            }
+        } else if (options.api == API.ION_ELEMENT_DOM) {
+            if (buffer != null) {
+                return this::fullyReadElementFromBuffer;
+            } else {
+                return this::fullyReadElementFromFile;
             }
         } else {
             throw new IllegalStateException("Illegal combination of options.");

--- a/src/com/amazon/ion/benchmark/MeasurableWriteTask.java
+++ b/src/com/amazon/ion/benchmark/MeasurableWriteTask.java
@@ -73,6 +73,14 @@ abstract class MeasurableWriteTask<T> implements MeasurableTask {
     abstract void generateWriteInstructionsStreaming(Consumer<WriteInstruction<T>> instructionsSink) throws IOException;
 
     /**
+     * Generate a sequence of WriteInstructions that re-write the input file with the configured options using the
+     * IonElement API.
+     * @param instructionsSink the sink for the sequence of generated WriteInstructions.
+     * @throws IOException if thrown when generating WriteInstructions.
+     */
+    abstract void generateWriteInstructionsElement(Consumer<WriteInstruction<T>> instructionsSink) throws IOException;
+
+    /**
      * @return a new writer context instance.
      * @param outputStream the OutputStream to which the new writer will write.
      * @throws IOException if thrown during construction of the context.
@@ -95,6 +103,9 @@ abstract class MeasurableWriteTask<T> implements MeasurableTask {
                 break;
             case DOM:
                 generateWriteInstructionsDom(writeInstructions::add);
+                break;
+            case ION_ELEMENT_DOM:
+                generateWriteInstructionsElement(writeInstructions::add);
                 break;
         }
     }

--- a/src/com/amazon/ion/benchmark/OptionsCombinationBase.java
+++ b/src/com/amazon/ion/benchmark/OptionsCombinationBase.java
@@ -92,6 +92,11 @@ abstract class OptionsCombinationBase {
         limit = getOrDefault(optionsCombinationStruct, LIMIT_NAME, val -> ((IonInt) val).intValue(), Integer.MAX_VALUE);
         jsonUseBigDecimals = getOrDefault(optionsCombinationStruct, JSON_USE_BIG_DECIMALS_NAME, val -> ((IonBool) val).booleanValue(), true);
         autoFlush = getOrDefault(optionsCombinationStruct, AUTO_FLUSH_ENABLED, val -> ((IonBool) val).booleanValue(), false);
+
+        // Validate that ION_ELEMENT_DOM is only used with Ion formats
+        if (api == API.ION_ELEMENT_DOM && !format.isIon()) {
+            throw new IllegalArgumentException("ION_ELEMENT_DOM API can only be used with Ion formats (ion_binary or ion_text), not with " + format.name().toLowerCase());
+        }
     }
 
     /**

--- a/src/com/amazon/ion/benchmark/OptionsMatrixBase.java
+++ b/src/com/amazon/ion/benchmark/OptionsMatrixBase.java
@@ -54,6 +54,9 @@ abstract class OptionsMatrixBase {
     static final Predicate<IonStruct> OPTION_ONLY_APPLIES_TO_ION_STREAMING = s -> {
         return OPTION_ONLY_APPLIES_TO_ION.test(s) && API.STREAMING.name().equals(getStringValue(s, API_NAME));
     };
+    static final Predicate<IonStruct> OPTION_ONLY_APPLIES_TO_ION_ELEMENT_DOM = s -> {
+        return OPTION_ONLY_APPLIES_TO_ION.test(s) && API.ION_ELEMENT_DOM.name().equals(getStringValue(s, API_NAME));
+    };
     static final Predicate<IonStruct> OPTION_ONLY_APPLIES_TO_JSON = s -> {
         return Format.JSON.name().equals(getStringValue(s, FORMAT_NAME));
     };

--- a/tst/com/amazon/ion/benchmark/OptionsTest.java
+++ b/tst/com/amazon/ion/benchmark/OptionsTest.java
@@ -759,7 +759,7 @@ public class OptionsTest {
     }
 
     @Test
-    public void readBothTextAndIonUsingIonElementDom() throws Exception {
+    public void readBothTextAndBinaryUsingIonElementDom() throws Exception {
         List<ReadOptionsCombination> optionsCombinations = parseOptionsCombinations(
                 "read",
                 "--format",

--- a/tst/com/amazon/ion/benchmark/OptionsTest.java
+++ b/tst/com/amazon/ion/benchmark/OptionsTest.java
@@ -868,7 +868,7 @@ public class OptionsTest {
     }
 
     @Test
-    public void readBinaryWithLimitFromFileUsingIonElementDom() throws Exception {
+    public void readBinaryAndTextWithLimitFromFileUsingIonElementDom() throws Exception {
         List<ReadOptionsCombination> optionsCombinations = parseOptionsCombinations(
                 "read",
                 "--limit",

--- a/tst/com/amazon/ion/benchmark/OptionsTest.java
+++ b/tst/com/amazon/ion/benchmark/OptionsTest.java
@@ -661,6 +661,46 @@ public class OptionsTest {
     }
 
     @Test
+    public void writeTextUsingIonElementDom() throws Exception {
+        List<WriteOptionsCombination> optionsCombinations = parseOptionsCombinations(
+                "write",
+                "--format",
+                "ion_text",
+                "--api",
+                "ion_element_dom",
+                "--io-type",
+                "buffer",
+                "--io-type",
+                "file",
+                "textStructs.ion"
+        );
+        assertEquals(2, optionsCombinations.size());
+        List<ExpectedWriteOptionsCombination> expectedCombinations = new ArrayList<>(2);
+        expectedCombinations.add(ExpectedWriteOptionsCombination.defaultOptions()
+                .api(API.ION_ELEMENT_DOM)
+                .format(Format.ION_TEXT)
+                .ioType(IoType.BUFFER)
+        );
+        expectedCombinations.add(ExpectedWriteOptionsCombination.defaultOptions()
+                .api(API.ION_ELEMENT_DOM)
+                .format(Format.ION_TEXT)
+                .ioType(IoType.FILE)
+        );
+
+        for (WriteOptionsCombination optionsCombination : optionsCombinations) {
+            expectedCombinations.removeIf(candidate -> {
+                return candidate.api == API.ION_ELEMENT_DOM
+                        && candidate.format == Format.ION_TEXT
+                        && candidate.ioType == optionsCombination.ioType;
+            });
+
+            assertWriteTaskExecutesCorrectly("binaryStructs.10n", optionsCombination, Format.ION_TEXT, optionsCombination.ioType);
+            assertWriteTaskExecutesCorrectly("textStructs.ion", optionsCombination, Format.ION_TEXT, optionsCombination.ioType);
+        }
+        assertTrue(expectedCombinations.isEmpty());
+    }
+
+    @Test
     public void readBothTextAndIonUsingBothDomAndReader() throws Exception {
         List<ReadOptionsCombination> optionsCombinations = parseOptionsCombinations(
             "read",
@@ -713,6 +753,51 @@ public class OptionsTest {
                 optionsCombination,
                 optionsCombination.format,
                 optionsCombination.format != Format.ION_TEXT
+            );
+        }
+        assertTrue(expectedCombinations.isEmpty());
+    }
+
+    @Test
+    public void readBothTextAndIonUsingIonElementDom() throws Exception {
+        List<ReadOptionsCombination> optionsCombinations = parseOptionsCombinations(
+                "read",
+                "--format",
+                "ion_text",
+                "--format",
+                "ion_binary",
+                "--io-type",
+                "buffer",
+                "--api",
+                "ion_element_dom",
+                "binaryStructs.10n"
+        );
+        assertEquals(2, optionsCombinations.size());
+        List<ExpectedReadOptionsCombination> expectedCombinations = new ArrayList<>(2);
+        expectedCombinations.add(ExpectedReadOptionsCombination.defaultOptions()
+                .ioType(IoType.BUFFER)
+                .format(Format.ION_TEXT)
+                .api(API.ION_ELEMENT_DOM)
+        );
+        expectedCombinations.add(ExpectedReadOptionsCombination.defaultOptions()
+                .ioType(IoType.BUFFER)
+                .format(Format.ION_BINARY)
+                .api(API.ION_ELEMENT_DOM)
+        );
+        for (ReadOptionsCombination optionsCombination : optionsCombinations) {
+            expectedCombinations.removeIf(candidate -> candidate.format == optionsCombination.format
+                    && candidate.api == optionsCombination.api);
+            assertReadTaskExecutesCorrectly(
+                    "binaryStructs.10n",
+                    optionsCombination,
+                    optionsCombination.format,
+                    optionsCombination.format != Format.ION_BINARY
+            );
+            assertReadTaskExecutesCorrectly(
+                    "textStructs.ion",
+                    optionsCombination,
+                    optionsCombination.format,
+                    optionsCombination.format != Format.ION_TEXT
             );
         }
         assertTrue(expectedCombinations.isEmpty());
@@ -783,6 +868,37 @@ public class OptionsTest {
     }
 
     @Test
+    public void readBinaryWithLimitFromFileUsingIonElementDom() throws Exception {
+        List<ReadOptionsCombination> optionsCombinations = parseOptionsCombinations(
+                "read",
+                "--limit",
+                "1",
+                "--io-type",
+                "file",
+                "--format",
+                "ion_text",
+                "--format",
+                "ion_binary",
+                "--api",
+                "ion_element_dom",
+                "binaryStructs.10n"
+        );
+        assertEquals(2, optionsCombinations.size());
+        List<ExpectedReadOptionsCombination> expectedCombinations = new ArrayList<>(2);
+        expectedCombinations.add(ExpectedReadOptionsCombination.defaultOptions().limit(1).api(API.ION_ELEMENT_DOM).format(Format.ION_BINARY));
+        expectedCombinations.add(ExpectedReadOptionsCombination.defaultOptions().limit(1).api(API.ION_ELEMENT_DOM).format(Format.ION_TEXT));
+
+        for (ReadOptionsCombination optionsCombination : optionsCombinations) {
+            expectedCombinations.removeIf(candidate -> candidate.format == optionsCombination.format);
+            assertEquals(1, optionsCombination.limit);
+
+            assertReadTaskExecutesCorrectly("binaryStructs.10n", optionsCombination, optionsCombination.format, true);
+            assertReadTaskExecutesCorrectly("textStructs.ion", optionsCombination, optionsCombination.format, true);
+        }
+        assertTrue(expectedCombinations.isEmpty());
+    }
+
+    @Test
     public void writeBinaryWithLimitUsingWriterAndDOM() throws Exception {
         List<WriteOptionsCombination> optionsCombinations = parseOptionsCombinations(
             "write",
@@ -798,6 +914,30 @@ public class OptionsTest {
         List<ExpectedWriteOptionsCombination> expectedCombinations = new ArrayList<>(2);
         expectedCombinations.add(ExpectedWriteOptionsCombination.defaultOptions().limit(1).api(API.DOM));
         expectedCombinations.add(ExpectedWriteOptionsCombination.defaultOptions().limit(1).api(API.STREAMING));
+
+        for (WriteOptionsCombination optionsCombination : optionsCombinations) {
+            expectedCombinations.removeIf(candidate -> candidate.api == optionsCombination.api);
+            assertEquals(1, optionsCombination.limit);
+
+            assertWriteTaskExecutesCorrectly("binaryStructs.10n", optionsCombination, Format.ION_BINARY, IoType.FILE);
+            assertWriteTaskExecutesCorrectly("textStructs.ion", optionsCombination, Format.ION_BINARY, IoType.FILE);
+        }
+        assertTrue(expectedCombinations.isEmpty());
+    }
+
+    @Test
+    public void writeBinaryWithLimitUsingIonElementDOM() throws Exception {
+        List<WriteOptionsCombination> optionsCombinations = parseOptionsCombinations(
+                "write",
+                "--limit",
+                "1",
+                "--api",
+                "ion_element_dom",
+                "binaryStructs.10n"
+        );
+        assertEquals(1, optionsCombinations.size());
+        List<ExpectedWriteOptionsCombination> expectedCombinations = new ArrayList<>(1);
+        expectedCombinations.add(ExpectedWriteOptionsCombination.defaultOptions().limit(1).api(API.ION_ELEMENT_DOM));
 
         for (WriteOptionsCombination optionsCombination : optionsCombinations) {
             expectedCombinations.removeIf(candidate -> candidate.api == optionsCombination.api);


### PR DESCRIPTION
**Summary**
This PR adds support for the `ION_ELEMENT_DOM` API to the ion-java-benchmark-cli, enabling benchmarking of the IonElement library from ion-element-kotlin alongside the existing STREAMING and DOM APIs.

**Changes**
1. API Enum Enhancement (`API.java`)
- Added `ION_ELEMENT_DOM` enum value with documentation

2. Read Task Implementation (`IonMeasurableReadTask.java`)
- Implemented element reading methods for buffer and file operations
- Added proper resource management and side effect consumer integration

3. Write Task Implementation (`IonMeasurableWriteTask.java`)
- Added `generateWriteInstructionsElement()` method
- Integrated element processing with limits and flush period support

4. Task Routing (`MeasurableReadTask.java` & `MeasurableWriteTask.java`)
- Added `ION_ELEMENT_DOM` routing in `getTask()` and `setUpTrial()` methods

5. CLI Documentation (`Main.java`)
- Updated `--api` option to include `ion_element_dom` with format restrictions

6. Dependencies (`pom.xml`)
- Added ion-element (1.3.0) and Kotlin dependencies

7. Test Coverage (`OptionsTest.java`)
- Added comprehensive tests for read/write operations with various configurations

**Performance Analysis**
Evaluated on three Ion corpus datasets, including both Ion text and Ion binary data, IonElement shows an average of ~37.09% increase in `primary_score` of performance compared to IonValue.