### PR TITLE
Compare normalized allocation rate instead of non-normalized in compare command

### DIFF
--- a/src/com/amazon/ion/benchmark/ParseAndCompareBenchmarkResults.java
+++ b/src/com/amazon/ion/benchmark/ParseAndCompareBenchmarkResults.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.stream.DoubleStream;
 
 public class ParseAndCompareBenchmarkResults {
-    public static final List<String> BENCHMARK_SCORE_KEYWORDS = Arrays.asList("speed", "Heap usage", "Serialized size", "·gc.alloc.rate");
+    public static final List<String> BENCHMARK_SCORE_KEYWORDS = Arrays.asList("speed", "Heap usage", "Serialized size", "·gc.alloc.rate.norm");
     private static final String PRIMARY_METRIC = "primaryMetric";
     private static final String SECONDARY_METRIC = "secondaryMetrics";
     private static final String SPEED = "speed";

--- a/tst/com/amazon/ion/benchmark/OptionsTest.java
+++ b/tst/com/amazon/ion/benchmark/OptionsTest.java
@@ -16,15 +16,18 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -34,6 +37,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertArrayEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
 
 public class OptionsTest {
 
@@ -2241,5 +2246,58 @@ public class OptionsTest {
         double expectResult = -0.22035698907090617;
         double realResult = ParseAndCompareBenchmarkResults.detectRegression(before, after);
         assertEquals(expectResult, realResult, 1e-16);
+    }
+
+    @Test
+    public void testDetectRegressionsInRegressedRun() throws Exception {
+        final Path beforeRun = fileInTestDirectory("benchmark-better.ion");
+        final Path afterRun  = fileInTestDirectory("benchmark-worse.ion");
+
+        final String[] expectedOutputs = new String[] {
+            "regression on speed",
+            "regression on ·gc.alloc.rate.norm",
+        };
+
+        final PrintStream standardOut = System.out;
+        final ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
+
+        System.setOut(new PrintStream(outputStreamCaptor));
+
+        ParseAndCompareBenchmarkResults.compareResult(
+            new HashMap<String, Object>() {{
+                put("--benchmark-result-previous", beforeRun);
+                put("--benchmark-result-new", afterRun);
+            }}
+        );
+
+        System.setOut(standardOut);
+
+        final String output = outputStreamCaptor.toString();
+        for(final String expectedOutput : expectedOutputs) {
+            assertThat("Benchmark comparison should show " + expectedOutput, output, containsString(expectedOutput));
+        }
+    }
+
+    @Test
+    public void testDetectNoRegressionsInImprovedRun() throws Exception {
+        final Path beforeRun = fileInTestDirectory("benchmark-worse.ion");
+        final Path afterRun  = fileInTestDirectory("benchmark-better.ion");
+
+        final PrintStream standardOut = System.out;
+        final ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
+
+        System.setOut(new PrintStream(outputStreamCaptor));
+
+        ParseAndCompareBenchmarkResults.compareResult(
+            new HashMap<String, Object>() {{
+                put("--benchmark-result-previous", beforeRun);
+                put("--benchmark-result-new", afterRun);
+            }}
+        );
+
+        System.setOut(standardOut);
+
+        final String output = outputStreamCaptor.toString();
+        assertTrue("Comparison with improved run should show no regressions", output.trim().isEmpty());
     }
 }

--- a/tst/com/amazon/ion/benchmark/benchmark-better.ion
+++ b/tst/com/amazon/ion/benchmark/benchmark-better.ion
@@ -1,0 +1,208 @@
+/* This is abridged benchmark data containing mostly only what the comparison tool looks at. */
+[
+    {
+        "jmhVersion" : "1.23",
+        "benchmark" : "com.amazon.ion.benchmark.Bench.run",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "21.0.8",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "21.0.8+9-LTS",
+        "warmupIterations" : 3,
+        "warmupTime" : "10 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "input" : "/Users/austnwil/testfiles/single_blob.10n",
+            "options" : "read::{f:ION_BINARY,t:FILE,a:DOM,R:INCREMENTAL}"
+        },
+        "primaryMetric" : {
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    1.7229602785529716,
+                    1.7869141434440872,
+                    1.8833532843967626,
+                    1.9102353418640183,
+                    2.0848277396289348
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+            "Heap usage" : {
+                "scoreUnit" : "MB",
+                "rawData" : [
+                    [
+                        7176.031856,
+                        10363.71396,
+                        8132.42224,
+                        12653.937424,
+                        11127.09792
+                    ]
+                ]
+            },
+            "Serialized size" : {
+                "scoreUnit" : "MB",
+                "rawData" : [
+                    [
+                        10.485769,
+                        10.485769,
+                        10.485769,
+                        10.485769,
+                        10.485769
+                    ]
+                ]
+            },
+            "·gc.alloc.rate" : {
+                "scoreUnit" : "MB/sec",
+                "rawData" : [
+                    [
+                        19910.396847742537,
+                        19204.42179663338,
+                        18214.839152185657,
+                        17962.21511594979,
+                        16455.56235208737
+                    ]
+                ]
+            },
+            "·gc.alloc.rate.norm" : {
+                "scoreUnit" : "B/op",
+                "rawData" : [
+                    [
+                        3.779312642342808E7,
+                        3.779312387281172E7,
+                        3.779312205985319E7,
+                        3.779310153399542E7,
+                        3.779307187325412E7
+                    ]
+                ]
+            },
+            "·gc.churn.CodeHeap_'profiled_nmethods'" : {
+                "scoreUnit" : "MB/sec",
+                "rawData" : [
+                    [
+                        0.004669828106274599,
+                        0.0021494990078836235,
+                        4.063972574604714E-4,
+                        6.390287244644159E-4,
+                        0.0023468868723043827
+                    ]
+                ]
+            },
+            "·gc.churn.CodeHeap_'profiled_nmethods'.norm" : {
+                "scoreUnit" : "B/op",
+                "rawData" : [
+                    [
+                        8.8640826873385,
+                        4.230082172204359,
+                        0.8432147562582345,
+                        1.3445378151260505,
+                        5.390035438815927
+                    ]
+                ]
+            },
+            "·gc.churn.G1_Eden_Space" : {
+                "scoreUnit" : "MB/sec",
+                "rawData" : [
+                    [
+                        25.884136970834856,
+                        25.128084920874688,
+                        25.11172776979063,
+                        21.3204149385818,
+                        17.512516314142676
+                    ]
+                ]
+            },
+            "·gc.churn.G1_Eden_Space.norm" : {
+                "scoreUnit" : "B/op",
+                "rawData" : [
+                    [
+                        49132.24323858743,
+                        49450.529474812436,
+                        52103.1552795031,
+                        44858.866310160425,
+                        40220.55117781947
+                    ]
+                ]
+            },
+            "·gc.churn.G1_Old_Gen" : {
+                "scoreUnit" : "MB/sec",
+                "rawData" : [
+                    [
+                        30285.186602151087,
+                        28898.80789628265,
+                        27564.287424069968,
+                        26760.904876329958,
+                        24558.626490962484
+                    ]
+                ]
+            },
+            "·gc.churn.G1_Old_Gen.norm" : {
+                "scoreUnit" : "B/op",
+                "rawData" : [
+                    [
+                        5.748614127407408E7,
+                        5.687108095033941E7,
+                        5.7191857166949E7,
+                        5.630583915202445E7,
+                        5.6403173360016674E7
+                    ]
+                ]
+            },
+            "·gc.churn.G1_Survivor_Space" : {
+                "scoreUnit" : "MB/sec",
+                "rawData" : [
+                    [
+                        0.08314210749660168,
+                        0.08693561595533643,
+                        0.07787587446086283,
+                        0.07113406339896051,
+                        0.059222586488675996
+                    ]
+                ]
+            },
+            "·gc.churn.G1_Survivor_Space.norm" : {
+                "scoreUnit" : "B/op",
+                "rawData" : [
+                    [
+                        157.8170542635659,
+                        171.08395855662738,
+                        161.5810276679842,
+                        149.66844919786095,
+                        136.01500938086303
+                    ]
+                ]
+            },
+            "·gc.count" : {
+                "scoreUnit" : "counts",
+                "rawData" : [
+                    [
+                        91.0,
+                        89.0,
+                        85.0,
+                        79.0,
+                        66.0
+                    ]
+                ]
+            },
+            "·gc.time" : {
+                "scoreUnit" : "ms",
+                "rawData" : [
+                    [
+                        67.0,
+                        66.0,
+                        63.0,
+                        65.0,
+                        63.0
+                    ]
+                ]
+            }
+        }
+    }
+]

--- a/tst/com/amazon/ion/benchmark/benchmark-worse.ion
+++ b/tst/com/amazon/ion/benchmark/benchmark-worse.ion
@@ -1,0 +1,208 @@
+/* This is abridged benchmark data containing mostly only what the comparison tool looks at. */
+[
+    {
+        "jmhVersion" : "1.23",
+        "benchmark" : "com.amazon.ion.benchmark.Bench.run",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/amazon-corretto-21.jdk/Contents/Home/bin/java",
+        "jvmArgs" : [
+        ],
+        "jdkVersion" : "21.0.8",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "21.0.8+9-LTS",
+        "warmupIterations" : 3,
+        "warmupTime" : "10 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "input" : "/Users/austnwil/testfiles/single_blob.10n",
+            "options" : "read::{f:ION_BINARY,t:FILE,a:DOM,R:INCREMENTAL}"
+        },
+        "primaryMetric" : {
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    2.7229602785529716,
+                    2.7869141434440872,
+                    2.8833532843967626,
+                    2.9102353418640183,
+                    3.0848277396289348
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+            "Heap usage" : {
+                "scoreUnit" : "MB",
+                "rawData" : [
+                    [
+                        7176.031856,
+                        10363.71396,
+                        8132.42224,
+                        12653.937424,
+                        11127.09792
+                    ]
+                ]
+            },
+            "Serialized size" : {
+                "scoreUnit" : "MB",
+                "rawData" : [
+                    [
+                        10.485769,
+                        10.485769,
+                        10.485769,
+                        10.485769,
+                        10.485769
+                    ]
+                ]
+            },
+            "·gc.alloc.rate" : {
+                "scoreUnit" : "MB/sec",
+                "rawData" : [
+                    [
+                        19910.396847742537,
+                        19204.42179663338,
+                        18214.839152185657,
+                        17962.21511594979,
+                        16455.56235208737
+                    ]
+                ]
+            },
+            "·gc.alloc.rate.norm" : {
+                "scoreUnit" : "B/op",
+                "rawData" : [
+                    [
+                        4.779312642342808E7,
+                        4.779312387281172E7,
+                        4.779312205985319E7,
+                        4.779310153399542E7,
+                        4.779307187325412E7
+                    ]
+                ]
+            },
+            "·gc.churn.CodeHeap_'profiled_nmethods'" : {
+                "scoreUnit" : "MB/sec",
+                "rawData" : [
+                    [
+                        0.004669828106274599,
+                        0.0021494990078836235,
+                        4.063972574604714E-4,
+                        6.390287244644159E-4,
+                        0.0023468868723043827
+                    ]
+                ]
+            },
+            "·gc.churn.CodeHeap_'profiled_nmethods'.norm" : {
+                "scoreUnit" : "B/op",
+                "rawData" : [
+                    [
+                        8.8640826873385,
+                        4.230082172204359,
+                        0.8432147562582345,
+                        1.3445378151260505,
+                        5.390035438815927
+                    ]
+                ]
+            },
+            "·gc.churn.G1_Eden_Space" : {
+                "scoreUnit" : "MB/sec",
+                "rawData" : [
+                    [
+                        25.884136970834856,
+                        25.128084920874688,
+                        25.11172776979063,
+                        21.3204149385818,
+                        17.512516314142676
+                    ]
+                ]
+            },
+            "·gc.churn.G1_Eden_Space.norm" : {
+                "scoreUnit" : "B/op",
+                "rawData" : [
+                    [
+                        49132.24323858743,
+                        49450.529474812436,
+                        52103.1552795031,
+                        44858.866310160425,
+                        40220.55117781947
+                    ]
+                ]
+            },
+            "·gc.churn.G1_Old_Gen" : {
+                "scoreUnit" : "MB/sec",
+                "rawData" : [
+                    [
+                        30285.186602151087,
+                        28898.80789628265,
+                        27564.287424069968,
+                        26760.904876329958,
+                        24558.626490962484
+                    ]
+                ]
+            },
+            "·gc.churn.G1_Old_Gen.norm" : {
+                "scoreUnit" : "B/op",
+                "rawData" : [
+                    [
+                        5.748614127407408E7,
+                        5.687108095033941E7,
+                        5.7191857166949E7,
+                        5.630583915202445E7,
+                        5.6403173360016674E7
+                    ]
+                ]
+            },
+            "·gc.churn.G1_Survivor_Space" : {
+                "scoreUnit" : "MB/sec",
+                "rawData" : [
+                    [
+                        0.08314210749660168,
+                        0.08693561595533643,
+                        0.07787587446086283,
+                        0.07113406339896051,
+                        0.059222586488675996
+                    ]
+                ]
+            },
+            "·gc.churn.G1_Survivor_Space.norm" : {
+                "scoreUnit" : "B/op",
+                "rawData" : [
+                    [
+                        157.8170542635659,
+                        171.08395855662738,
+                        161.5810276679842,
+                        149.66844919786095,
+                        136.01500938086303
+                    ]
+                ]
+            },
+            "·gc.count" : {
+                "scoreUnit" : "counts",
+                "rawData" : [
+                    [
+                        91.0,
+                        89.0,
+                        85.0,
+                        79.0,
+                        66.0
+                    ]
+                ]
+            },
+            "·gc.time" : {
+                "scoreUnit" : "ms",
+                "rawData" : [
+                    [
+                        67.0,
+                        66.0,
+                        63.0,
+                        65.0,
+                        63.0
+                    ]
+                ]
+            }
+        }
+    }
+]


### PR DESCRIPTION
### Description of changes:

`ion-java-benchmark-cli compare ...` will report regressions on average memory allocation rate/second (gc.alloc.rate), which is not a signal worth relying on since it is sensitive to execution speed. This changes the compare command to compare normalized allocation rate instead and adds a quick test.

This should reduce some false positives in the ion-java performance regression GitHub workflow, since I've noticed many of them are related to gc alloc rate.

_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
